### PR TITLE
changed export strategy to a simple babel conversion instead of webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-loader": "1.0.0"
   },
   "scripts": {
-    "compile": "rm -rf lib/ && BUILD_ENV=lib ./node_modules/.bin/webpack --bail --display-error-details",
+    "compile": "babel --ignore='**/__tests__/' -d lib/ src/",
     "test": "$npm_package_options_mocha \"src/**/__tests__/*-test.js\"",
     "lint": "./node_modules/eslint/bin/eslint.js -c linting/prod.yaml src/"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "api-flow",
   "description": "A flow written in ES6 using Immutable to convert between API description formats (Swagger, etc.) and other programs such as cURL command lines.",
   "keywords": ["api", "swagger", "paw", "curl", "api blueprint", "raml", "grape"],
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/api-flow.js",
   "license": "MIT",
   "homepage": "https://github.com/luckymarmot/API-Flow",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "yaml-js": "0.1.3"
   },
   "devDependencies": {
-    "babel": "6.5.2",
+    "babel-cli": "6.6.5",
     "babel-core": "6.4.0",
     "babel-eslint": "4.1.8",
     "babel-loader": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A flow written in ES6 using Immutable to convert between API description formats (Swagger, etc.) and other programs such as cURL command lines.",
   "keywords": ["api", "swagger", "paw", "curl", "api blueprint", "raml", "grape"],
   "version": "0.0.5",
-  "main": "lib/api-flow.js",
+  "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://github.com/luckymarmot/API-Flow",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "api-flow",
   "description": "A flow written in ES6 using Immutable to convert between API description formats (Swagger, etc.) and other programs such as cURL command lines.",
-  "keywords": ["api", "swagger", "paw", "curl", "api blueprint", "raml", "grape"],
+  "keywords": [
+    "api",
+    "swagger",
+    "paw",
+    "curl",
+    "api blueprint",
+    "raml",
+    "grape"
+  ],
   "version": "0.0.5",
   "main": "lib/index.js",
   "license": "MIT",
@@ -16,7 +24,9 @@
     "yaml-js": "0.1.3"
   },
   "devDependencies": {
+    "babel": "6.5.2",
     "babel-core": "6.4.0",
+    "babel-eslint": "4.1.8",
     "babel-loader": "6.2.0",
     "babel-plugin-rewire": "1.0.0-beta-3",
     "babel-plugin-transform-decorators": "6.3.13",
@@ -29,12 +39,11 @@
     "babel-preset-stage-3": "6.3.13",
     "babel-register": "6.3.13",
     "chai": "3.4.1",
+    "eslint": "1.3.1",
+    "eslint-loader": "1.0.0",
     "mocha": "2.3.4",
     "path": "0.12.7",
-    "webpack": "1.12.9",
-    "eslint": "1.3.1",
-    "babel-eslint": "4.1.8",
-    "eslint-loader": "1.0.0"
+    "webpack": "1.12.9"
   },
   "scripts": {
     "compile": "babel --ignore='**/__tests__/' -d lib/ src/",


### PR DESCRIPTION
Couldn't get webpack to work correctly, so we're going with a simpler Babel conversion instead for the time being.