### PR TITLE
Added Scope support to API-flow for OAuth2

### DIFF
--- a/src/immutables/Auth.js
+++ b/src/immutables/Auth.js
@@ -35,5 +35,6 @@ export class OAuth1Auth extends Immutable.Record({
 export class OAuth2Auth extends Immutable.Record({
     flow: null,
     authorizationUrl: null,
-    tokenUrl: null
+    tokenUrl: null,
+    scopes: Immutable.List()
 }) { }

--- a/src/importers/cURL/Parser.js
+++ b/src/importers/cURL/Parser.js
@@ -465,9 +465,11 @@ export default class CurlParser {
 
         const arg = this._popArg()
 
-        if (option === '--data' ||
-                option === '--data-raw' ||
-                option === '--data-binary') {
+        if (
+            option === '--data' ||
+            option === '--data-raw' ||
+            option === '--data-binary'
+        ) {
             let value = arg
 
             // resolve file reference @filename

--- a/src/importers/swagger/Parser.js
+++ b/src/importers/swagger/Parser.js
@@ -127,8 +127,11 @@ export default class SwaggerParser {
                         security.hasOwnProperty(key) &&
                         swaggerCollection.securityDefinitions[key]
                     ) {
-                        let definition = swaggerCollection
-                            .securityDefinitions[key]
+                        let definition = Immutable.fromJS(swaggerCollection
+                            .securityDefinitions[key])
+                        definition = definition.set(
+                            'scopes', new Immutable.List(security[key])
+                        )
                         return request
                             .setAuthType(definition.type, definition)
                     }

--- a/src/importers/swagger/Parser.js
+++ b/src/importers/swagger/Parser.js
@@ -133,7 +133,7 @@ export default class SwaggerParser {
                             'scopes', new Immutable.List(security[key])
                         )
                         return request
-                            .setAuthType(definition.type, definition)
+                            .setAuthType(definition.get('type'), definition)
                     }
                 }
             }

--- a/src/importers/swagger/__tests__/fixtures/Parser-fixtures.js
+++ b/src/importers/swagger/__tests__/fixtures/Parser-fixtures.js
@@ -944,7 +944,10 @@ export default class SwaggerFixtures {
                 output: new Request({
                     auth: new OAuth2Auth({
                         flow: 'implicit',
-                        authorizationUrl: 'http://s.com/oauth'
+                        authorizationUrl: 'http://s.com/oauth',
+                        scopes: new Immutable.List(
+                            [ 'write_pets', 'read_pets' ]
+                        )
                     })
                 })
             }


### PR DESCRIPTION
Don't mind the small change to the cURL Parser.

Added a `scopes` field in the OAuth2 representation.
Implemented scopes support in the Swagger importer.
Updated tests to account for scopes in OAuth2