### PR TITLE
prepublish to npm cleanup (v0.0.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "raml",
     "grape"
   ],
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://github.com/luckymarmot/API-Flow",

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,9 @@ import {
     OAuth2Auth
 } from './immutables/Auth'
 
+import SwaggerParser from 'importers/swagger/Parser'
+import CurlParser from 'importers/swagger/Parser'
+
 export default RequestContext
 export {
     Request,
@@ -36,4 +39,8 @@ export const Auth = {
     ApiKey: ApiKeyAuth,
     OAuth1: OAuth1Auth,
     OAuth2: OAuth2Auth
+}
+export const Parser = {
+    Swagger: SwaggerParser,
+    Curl: CurlParser
 }


### PR DESCRIPTION
Bumped version to 0.0.6
Added the Parsers to the public interface of api-flow