### PR TITLE
037 fix swagger global parameters

### DIFF
--- a/src/importers/swagger/Parser.js
+++ b/src/importers/swagger/Parser.js
@@ -34,6 +34,7 @@ export default class SwaggerParser {
             rootGroup = rootGroup.set('name', swaggerCollection.info.title)
             let pathLinkedRequests = this._applyFuncOverPathArchitecture(
                 swaggerCollection,
+                baseSchema,
                 ::this._createRequest
             )
 
@@ -238,13 +239,55 @@ export default class SwaggerParser {
         return tv4.validate(swag, swaggerSchema)
     }
 
+    _updateParametersInMethod(content, baseParams) {
+        // shallow copy
+        let params = (baseParams || []).map(d => { return d })
+        let contentParams = content.parameters || []
+        for (let param of contentParams) {
+            let name = param.name
+            let index = 0
+            let used = false
+            for (let _param of baseParams || []) {
+                let _name = _param.name
+                if (name === _name) {
+                    params[index] = param
+                    used = true
+                }
+                index += 1
+            }
+            if (!used) {
+                params.push(param)
+            }
+        }
+        return params
+    }
+
     // @tested
-    _applyFuncOverPathArchitecture(collection, func) {
+    _applyFuncOverPathArchitecture(collection, schema, func) {
         let architecture = {}
         for (let path in collection.paths) {
             if (collection.paths.hasOwnProperty(path)) {
                 architecture[path] = architecture[path] || {}
                 let methods = collection.paths[path]
+                if (methods.parameters) {
+                    let _params = new Schema()
+                    _params = _params
+                        .mergeSchema(methods.parameters)
+                        .resolve(schema)
+                        .toJS()
+
+                    let _methods = Object.keys(methods)
+                    let paramKey = _methods.indexOf('parameters')
+                    // remove paramKey
+                    _methods.splice(paramKey, 1)
+                    for (let method of _methods) {
+                        let params = this._updateParametersInMethod(
+                            methods[method],
+                            _params
+                        )
+                        methods[method].parameters = params
+                    }
+                }
                 for (let method in methods) {
                     if (
                         methods.hasOwnProperty(method) &&

--- a/src/importers/swagger/Parser.js
+++ b/src/importers/swagger/Parser.js
@@ -269,6 +269,7 @@ export default class SwaggerParser {
             if (collection.paths.hasOwnProperty(path)) {
                 architecture[path] = architecture[path] || {}
                 let methods = collection.paths[path]
+                let _methods = Object.keys(methods)
                 if (methods.parameters) {
                     let _params = new Schema()
                     _params = _params
@@ -276,10 +277,10 @@ export default class SwaggerParser {
                         .resolve(schema)
                         .toJS()
 
-                    let _methods = Object.keys(methods)
                     let paramKey = _methods.indexOf('parameters')
                     // remove paramKey
                     _methods.splice(paramKey, 1)
+
                     for (let method of _methods) {
                         let params = this._updateParametersInMethod(
                             methods[method],
@@ -288,18 +289,13 @@ export default class SwaggerParser {
                         methods[method].parameters = params
                     }
                 }
-                for (let method in methods) {
-                    if (
-                        methods.hasOwnProperty(method) &&
-                        method !== 'parameters'
-                    ) {
-                        architecture[path][method] = func(
-                            collection,
-                            path,
-                            method,
-                            methods[method]
-                        )
-                    }
+                for (let method of _methods) {
+                    architecture[path][method] = func(
+                        collection,
+                        path,
+                        method,
+                        methods[method]
+                    )
                 }
             }
         }

--- a/src/utils/TestUtils.js
+++ b/src/utils/TestUtils.js
@@ -62,10 +62,11 @@ class UnitTest {
     }
 
     assertEqual(a, b, message) {
-        let warn = (message ? message + '\n' : '') + `\n${a} \n!== \n${b}`
-        assert.isTrue(
-            Immutable.is(Immutable.fromJS(a), Immutable.fromJS(b)), warn
-        )
+        let A = Immutable.fromJS(a)
+        let B = Immutable.fromJS(b)
+        let comparison = Immutable.is(A, B)
+        let warn = (message ? message + '\n' : '') + `\n${A} \n!== \n${B}`
+        assert.isTrue(comparison, warn)
     }
 
     assertNotEqual(a, b) {


### PR DESCRIPTION
This PR fixes the propagation issue for parameters.
Fixes [issue#34](https://github.com/luckymarmot/API-Flow/issues/34)

Also fixes List support in `Schema` objects. Before, a list in a schema would be converted to an object with keys [0, 1, 2, 3, ...], when calling `schema.toJS()`. It is now correctly converted back to an array.