### PR TITLE
Postman Digest Auth Bugfix

### DIFF
--- a/src/parsers/postman/v1/Parser.js
+++ b/src/parsers/postman/v1/Parser.js
@@ -204,13 +204,15 @@ export default class PostmanParser {
         else {
             let kvList = params.match(/([^\s,]*="[^"]*")|([^\s,]*='[^']*')/g)
             kvList.forEach((kv) => {
-                let [ key, value ] = kv
+                let kvMatch = kv
                     .match(/([^=]*)=["'](.*)["']/)
-                    .slice(1, 3)
-                if (digestMap[key]) {
-                    auth = auth.set(key,
-                        this._referenceEnvironmentVariable(value)
-                    )
+                if (kvMatch) {
+                    let [ key, value ] = kvMatch.slice(1, 3)
+                    if (digestMap[key]) {
+                        auth = auth.set(key,
+                            this._referenceEnvironmentVariable(value)
+                        )
+                    }
                 }
             })
 


### PR DESCRIPTION
this should fix an issue with the postman importer around corrupted digest auth data in the header field (when no helper is present)