### PR TITLE
059 improve body curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ test:
 lint:
 	npm run lint
 
+validate: test lint
+
 npm-install:
 	npm install
 

--- a/src/parsers/cURL/Parser.js
+++ b/src/parsers/cURL/Parser.js
@@ -463,12 +463,18 @@ export default class CurlParser {
         let headers = _headers
         let contentType = headers.get('Content-Type') || null
 
+        console.log('hey there', urlEncodeFlag, JSON.stringify(body), JSON.stringify(headers))
         if (urlEncodeFlag) {
             // this is not form url encoded, but a plain body string or file
             if (body.count() === 1 && body.getIn([ 0, 'value' ]) === null) {
                 if (body.getIn([ 0, 'key' ]) instanceof ExoticReference) {
                     body = new Immutable.List([
                         this._formatParameter('body', body.getIn([ 0, 'key' ]))
+                    ])
+                }
+                else {
+                    body = new Immutable.List([
+                        this._formatParameter(null, body.getIn([ 0, 'key' ]))
                     ])
                 }
             }

--- a/src/parsers/cURL/Parser.js
+++ b/src/parsers/cURL/Parser.js
@@ -463,7 +463,6 @@ export default class CurlParser {
         let headers = _headers
         let contentType = headers.get('Content-Type') || null
 
-        console.log('hey there', urlEncodeFlag, JSON.stringify(body), JSON.stringify(headers))
         if (urlEncodeFlag) {
             // this is not form url encoded, but a plain body string or file
             if (body.count() === 1 && body.getIn([ 0, 'value' ]) === null) {

--- a/src/parsers/cURL/__tests__/Parser-test.js
+++ b/src/parsers/cURL/__tests__/Parser-test.js
@@ -1102,12 +1102,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: 'key',
-                            name: 'key',
-                            value: null,
+                            value: 'key',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ 'key' ])
                             ])
                         })
                     ])
@@ -1138,12 +1136,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: 'content',
-                            name: 'content',
-                            value: null,
+                            value: 'content',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ 'content' ])
                             ])
                         })
                     ])
@@ -1389,12 +1385,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: 'sometext',
-                            name: 'sometext',
-                            value: null,
+                            value: 'sometext',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ 'sometext' ])
                             ])
                         })
                     ])
@@ -1469,12 +1463,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: 'sometext',
-                            name: 'sometext',
-                            value: null,
+                            value: 'sometext',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ 'sometext' ])
                             ])
                         })
                     ])
@@ -1549,12 +1541,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: 'sometext',
-                            name: 'sometext',
-                            value: null,
+                            value: 'sometext',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ 'sometext' ])
                             ])
                         })
                     ])
@@ -1734,12 +1724,10 @@ export class TestCurlParser extends UnitTest {
                     ]),
                     body: new Immutable.List([
                         new Parameter({
-                            key: '@filename.txt',
-                            name: '@filename.txt',
-                            value: null,
+                            value: '@filename.txt',
                             type: 'string',
                             internals: new Immutable.List([
-                                new Constraint.Enum([ null ])
+                                new Constraint.Enum([ '@filename.txt' ])
                             ])
                         })
                     ])


### PR DESCRIPTION
I changed the way cURL stores body variables.

If a body parameter was a string instead of a key-value pair, It used to store the variable data in the `key` field of the parameter instead of the `data` field, which was not in line with the expected behavior from parsers.

it now correctly stores it in the `data` field.