### PR TITLE
079 postman placeholder

### DIFF
--- a/src/parsers/postman/v1/Parser.js
+++ b/src/parsers/postman/v1/Parser.js
@@ -93,10 +93,18 @@ export default class PostmanParser {
 
         if (this.references) {
             let keys = envs.keySeq()
-            for (let key of keys) {
-                let container = envs.get(key)
-                container = container.create(this.references)
-                envs = envs.set(key, container)
+
+            if (keys.length === 0) {
+                envs = envs.set('defpostmanenv', (new ReferenceContainer({
+                    name: 'Default Postman Environment'
+                })).create(this.references))
+            }
+            else {
+                for (let key of keys) {
+                    let container = envs.get(key)
+                    container = container.create(this.references)
+                    envs = envs.set(key, container)
+                }
             }
         }
 
@@ -432,9 +440,7 @@ export default class PostmanParser {
                     }
                 }
                 else {
-                    headerSet = headerSet.set(match[1],
-                        this._referenceEnvironmentVariable(match[2])
-                    )
+                    headerSet = headerSet.set(match[1], match[2])
                 }
             }
         }
@@ -596,23 +602,23 @@ export default class PostmanParser {
             params.push(param)
         }
         else if (req.dataMode === 'urlencoded' || req.dataMode === 'params') {
-            let contentType = this._extractContentType(headers)
-            if (!contentType && req.dataMode === 'urlencoded') {
-                let header = this._extractParam(
-                    'Content-Type', 'application/x-www-form-urlencoded'
-                )
-                contentType = 'application/x-www-form-urlencoded'
-                headers = headers.push(header)
-            }
-            else if (!contentType && req.dataMode === 'params') {
-                let header = this._extractParam(
-                    'Content-Type', 'multipart/form-data'
-                )
-                contentType = 'multipart/form-data'
-                headers = headers.push(header)
-            }
+            if (req.data && req.data.length) {
+                let contentType = this._extractContentType(headers)
+                if (!contentType && req.dataMode === 'urlencoded') {
+                    let header = this._extractParam(
+                        'Content-Type', 'application/x-www-form-urlencoded'
+                    )
+                    contentType = 'application/x-www-form-urlencoded'
+                    headers = headers.push(header)
+                }
+                else if (!contentType && req.dataMode === 'params') {
+                    let header = this._extractParam(
+                        'Content-Type', 'multipart/form-data'
+                    )
+                    contentType = 'multipart/form-data'
+                    headers = headers.push(header)
+                }
 
-            if (req.data) {
                 for (let _param of req.data) {
                     let param = this._extractParam(_param.key, _param.value)
                     if (contentType) {

--- a/src/serializers/paw/base-importer/BaseImporter.js
+++ b/src/serializers/paw/base-importer/BaseImporter.js
@@ -1212,7 +1212,6 @@ export default class BaseImporter {
                 return this._setReference(component)
             }
 
-            // This is going to cause confusion
             if (component instanceof LateResolutionReference) {
                 let match = (component.get('uri') || '')
                 .slice(12)


### PR DESCRIPTION
Fixed multiple bugs around environments in the Postman Parser + Paw Serializer.

- Now correctly imports auto generated environments when no environment is available
- DynamicStrings that should have contained a single component referencing an environment variable from Postman now correctly references to it, instead of returning an empty string.

Also fixes a bug where we would infer a `multipart/form-data` or `application/x-www-form-urlencoded` from the request if the request had no `Content-Type`, but also no body to send. Now only does this when there's a body to send.