### PR TITLE
Postman collection v2 parser & Swagger parser bugfix 

### DIFF
--- a/src/parsers/postman/v2/Parser.js
+++ b/src/parsers/postman/v2/Parser.js
@@ -625,8 +625,14 @@ export default class PostmanParser {
 
     _extractBodyParams(body, _headers) {
         let headers = _headers
+
+        if (!body) {
+            return [ new Immutable.List(), headers ]
+        }
+
         let params = []
         let contentType = this._extractContentType(headers)
+
         if (body.mode === 'raw') {
             let param = this._extractParam('body', body.raw || null)
             params.push(param)

--- a/src/parsers/swagger/Parser.js
+++ b/src/parsers/swagger/Parser.js
@@ -485,7 +485,7 @@ export default class SwaggerParser {
                 basePath = '/' + basePath
             }
 
-            if (!(basePath.indexOf('/') === 0)) {
+            if (basePath.indexOf('/') === basePath.length - 1) {
                 basePath = basePath.substr(0, basePath.length - 1)
             }
         }


### PR DESCRIPTION
* an undefined body in a request in a v2 collection caused the app to crash (postman)
* the `/` basePath was not properly trimmed (swagger)