### PR TITLE
085 - Fixes for duplicate params

### DIFF
--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -590,8 +590,6 @@ export default class PawParser {
 
         let val = dvManager.convert(component)
 
-        console.log('_formatHeaderComponent', key, isAuth, val, component)
-
         if (isAuth) {
             auth = this._formatAuthFromHeader(component)
             if (auth) {

--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -517,7 +517,7 @@ export default class PawParser {
             if (isAuth) {
                 let content = ds.getEvaluatedString()
                 let [ _param, auth ] = this._formatHeaderComponent(
-                    null,
+                    'Authorization',
                     content,
                     this.dvManager,
                     externals,
@@ -525,7 +525,7 @@ export default class PawParser {
                 )
 
                 if (_param) {
-                    value = value.push(_param)
+                    param = _param
                 }
 
                 if (auth) {
@@ -589,6 +589,9 @@ export default class PawParser {
         let auth = null
 
         let val = dvManager.convert(component)
+
+        console.log('_formatHeaderComponent', key, isAuth, val, component)
+
         if (isAuth) {
             auth = this._formatAuthFromHeader(component)
             if (auth) {
@@ -777,8 +780,14 @@ export default class PawParser {
 
         let params = []
         for (let key of keys) {
-            let query = this._formatQueryParam(key, queries[key], externals)
-            params.push(query)
+            let array = Array.isArray(queries[key]) ?
+                queries[key] :
+                [ queries[key] ]
+
+            for (let ds of array) {
+                let query = this._formatQueryParam(key, ds, externals)
+                params.push(query)
+            }
         }
 
         return new Immutable.List(params)
@@ -906,12 +915,19 @@ export default class PawParser {
 
                 let keys = Object.keys(urlEncoded)
                 for (let key of keys) {
-                    let param = this._formatQueryParam(
-                        key,
-                        urlEncoded[key],
-                        new Immutable.List([ external ])
-                    )
-                    params.push(param)
+                    let array = Array.isArray(urlEncoded[key]) ?
+                        urlEncoded[key] :
+                        [ urlEncoded[key] ]
+
+                    for (let ds of array) {
+                        let param = this._formatQueryParam(
+                            key,
+                            ds,
+                            new Immutable.List([ external ])
+                        )
+
+                        params.push(param)
+                    }
                 }
             }
             else if (

--- a/src/serializers/raml/Serializer.js
+++ b/src/serializers/raml/Serializer.js
@@ -626,7 +626,21 @@ export default class RAMLSerializer extends BaseSerializer {
 
         queries.forEach(param => {
             let named = this._convertParameterToNamedParameter(param)
-            Object.assign(result, named)
+            let name = Object.keys(named)[0]
+            let _param = result[name]
+            if (_param) {
+                if (
+                    _param.enum &&
+                    _param.enum.length === 1 &&
+                    _param.enum[0] === _param.default
+                ) {
+                    delete _param.enum
+                }
+                _param.repeat = true
+            }
+            else {
+                Object.assign(result, named)
+            }
         })
 
         return result
@@ -653,7 +667,21 @@ export default class RAMLSerializer extends BaseSerializer {
                 let params = filtered.get('body')
                 params.forEach(param => {
                     let named = this._convertParameterToNamedParameter(param)
-                    Object.assign(_body[constraint].formParameters, named)
+                    let name = Object.keys(named)[0]
+                    let _param = _body[constraint].formParameters[name]
+                    if (_param) {
+                        if (
+                            _param.enum &&
+                            _param.enum.length === 1 &&
+                            _param.enum[0] === _param.default
+                        ) {
+                            delete _param.enum
+                        }
+                        _param.repeat = true
+                    }
+                    else {
+                        Object.assign(_body[constraint].formParameters, named)
+                    }
                 })
             }
             else {

--- a/src/serializers/swagger/__tests__/Serializer-test.js
+++ b/src/serializers/swagger/__tests__/Serializer-test.js
@@ -1799,7 +1799,11 @@ export class TestSwaggerSerializer extends UnitTest {
         const expected = [
             {
                 name: 'api_key',
-                in: 'query'
+                in: 'query',
+                type: 'array',
+                items: {},
+                collectionFormat: 'multi',
+                'x-title': 'api_key'
             },
             {
                 name: 'Content-MD5',


### PR DESCRIPTION
Fixes an issue around an undocumented behavior of `request.getUrlEncodedBody(true)` in case of multiple parameters

Improves duplicate handling for swagger and RAML