### PR TITLE
088 All Around Bug Fixes

### DIFF
--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -1023,7 +1023,7 @@ export default class PawParser {
                 flow: grantMap[oauth2.grantType] || null,
                 authorizationUrl: oauth2.authorizationUrl || null,
                 tokenUrl: oauth2.tokenUrl || null,
-                scopes: scopes
+                scopes: new Immutable.List(scopes)
             })
             auths.push(auth)
         }

--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -889,7 +889,7 @@ export default class PawParser {
 
     _formatBody(req) {
         let params = []
-        let contentType
+        let contentType = req.getHeaderByName('Content-Type')
 
         let body = req.getBody(true)
         let urlEncoded = req.getUrlEncodedBody(true)
@@ -902,7 +902,7 @@ export default class PawParser {
                 urlEncoded &&
                 urlEncoded !== null
             ) {
-                contentType = 'application/x-www-form-urlencoded'
+                contentType = contentType || 'application/x-www-form-urlencoded'
                 external = new Parameter({
                     key: 'Content-Type',
                     type: 'string',
@@ -932,7 +932,7 @@ export default class PawParser {
                 formData &&
                 formData !== null
             ) {
-                contentType = 'multipart/form-data'
+                contentType = contentType || 'multipart/form-data'
                 external = new Parameter({
                     key: 'Content-Type',
                     type: 'string',
@@ -954,7 +954,7 @@ export default class PawParser {
         }
 
         if (body && params.length === 0) {
-            contentType = 'text/plain'
+            contentType = contentType || 'text/plain'
             external = new Parameter({
                 key: 'Content-Type',
                 type: 'string',

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -84,7 +84,7 @@ export default class RAMLParser {
             }
             return
         }, error => {
-            throw new Error(error.message)
+            throw error
         })
     }
 

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -84,7 +84,11 @@ export default class RAMLParser {
             }
             return
         }, error => {
-            throw error
+            let msg = 'failed to parse RAML file'
+            if (error.message) {
+                msg += ' with reason: ' + error.message
+            }
+            throw new Error(msg)
         })
     }
 

--- a/src/runners/flow-webworker.js
+++ b/src/runners/flow-webworker.js
@@ -117,7 +117,6 @@ export default class FlowWorker {
         let environment = new BrowserEnvironment()
         let resolver = new ContextResolver(environment)
 
-        console.log('starting parse')
         return contentPromise.then((content) => {
             let item = {
                 url: url,
@@ -134,13 +133,11 @@ export default class FlowWorker {
             }
 
             return promise.then(context => {
-                console.log('parse is done')
                 return resolver.resolveAll(
                     parser.item,
                     context,
                     opts.get('resolver')
                 ).then(_context => {
-                    console.log('resolution is done')
                     try {
                         let final = serializer
                             .serialize(
@@ -148,7 +145,6 @@ export default class FlowWorker {
                                 opts.get('serializer')
                             )
                         let error = serializer.validate(final)
-                        console.log('serialization is done', error, final)
                         if (error) {
                             throw error
                         }
@@ -157,7 +153,6 @@ export default class FlowWorker {
                         }
                     }
                     catch (e) {
-                        console.log('got error', e)
                         throw e
                     }
                 }).catch(error => {

--- a/src/runners/flow-webworker.js
+++ b/src/runners/flow-webworker.js
@@ -67,26 +67,26 @@ export default class FlowWorker {
     }
 
     transform(input, _opts) {
-        let parserMap = {
+        const parserMap = {
             swagger: SwaggerParser,
             raml: RAMLParser,
             postman: PostmanParser,
             curl: CurlParser
         }
 
-        let serializerMap = {
+        const serializerMap = {
             swagger: SwaggerSerializer,
             raml: RAMLSerializer,
             postman: PostmanSerializer,
             curl: CurlSerializer
         }
 
-        let opts = new Options(_opts)
+        const opts = new Options(_opts)
 
-        let sourceFormat = opts.getIn([ 'parser', 'name' ])
-        let sourceVersion = opts.getIn([ 'parser', 'version' ])
-        let target = opts.getIn([ 'serializer', 'name' ])
-        let base = opts.getIn([ 'resolver', 'base' ])
+        const sourceFormat = opts.getIn([ 'parser', 'name' ])
+        const sourceVersion = opts.getIn([ 'parser', 'version' ])
+        const target = opts.getIn([ 'serializer', 'name' ])
+        const base = opts.getIn([ 'resolver', 'base' ])
 
         if (!parserMap[sourceFormat]) {
             return new Promise((_, reject) => {
@@ -112,10 +112,10 @@ export default class FlowWorker {
             url = input
         }
 
-        let parser = new parserMap[sourceFormat](sourceVersion)
-        let serializer = new serializerMap[target]()
-        let environment = new BrowserEnvironment()
-        let resolver = new ContextResolver(environment)
+        const parser = new parserMap[sourceFormat](sourceVersion)
+        const serializer = new serializerMap[target]()
+        const environment = new BrowserEnvironment()
+        const resolver = new ContextResolver(environment)
 
         return contentPromise.then((content) => {
             let item = {
@@ -123,7 +123,15 @@ export default class FlowWorker {
                 content: content
             }
 
-            let promise = parser.parse(item, opts.get('parser'))
+            let promise
+            try {
+                promise = parser.parse(item, opts.get('parser'))
+            }
+            catch (e) {
+                return new Promise((resolve, reject) => {
+                    reject(e)
+                })
+            }
 
             if (typeof promise.then !== 'function') {
                 let value = promise
@@ -165,6 +173,8 @@ export default class FlowWorker {
             })
         }, error => {
             throw error
+        }).catch(err => {
+            throw err
         })
     }
 
@@ -282,7 +292,7 @@ export default class FlowWorker {
             let error = _error
 
             if (_error instanceof Error) {
-                error = _error.msg
+                error = _error.message || _error.name || 'unknown error'
             }
 
             self.postMessage({
@@ -300,7 +310,7 @@ export default class FlowWorker {
             let error = _error
 
             if (_error instanceof Error) {
-                error = _error.msg
+                error = _error.message || _error.name || 'unknown error'
             }
 
             self.postMessage({

--- a/src/runners/flow-webworker.js
+++ b/src/runners/flow-webworker.js
@@ -89,11 +89,15 @@ export default class FlowWorker {
         let base = opts.getIn([ 'resolver', 'base' ])
 
         if (!parserMap[sourceFormat]) {
-            throw new Error('unrecognized source format')
+            return new Promise((_, reject) => {
+                reject(new Error('unrecognized source format'))
+            })
         }
 
         if (!serializerMap[target]) {
-            throw new Error('unrecognized target format')
+            return new Promise((_, reject) => {
+                reject(new Error('unrecognized target format'))
+            })
         }
 
         let url = null
@@ -113,6 +117,7 @@ export default class FlowWorker {
         let environment = new BrowserEnvironment()
         let resolver = new ContextResolver(environment)
 
+        console.log('starting parse')
         return contentPromise.then((content) => {
             let item = {
                 url: url,
@@ -129,11 +134,13 @@ export default class FlowWorker {
             }
 
             return promise.then(context => {
+                console.log('parse is done')
                 return resolver.resolveAll(
                     parser.item,
                     context,
                     opts.get('resolver')
                 ).then(_context => {
+                    console.log('resolution is done')
                     try {
                         let final = serializer
                             .serialize(
@@ -141,6 +148,7 @@ export default class FlowWorker {
                                 opts.get('serializer')
                             )
                         let error = serializer.validate(final)
+                        console.log('serialization is done', error, final)
                         if (error) {
                             throw error
                         }
@@ -149,6 +157,7 @@ export default class FlowWorker {
                         }
                     }
                     catch (e) {
+                        console.log('got error', e)
                         throw e
                     }
                 }).catch(error => {
@@ -159,6 +168,8 @@ export default class FlowWorker {
             }).catch(err => {
                 throw err
             })
+        }, error => {
+            throw error
         })
     }
 

--- a/src/serializers/postman/Serializer.js
+++ b/src/serializers/postman/Serializer.js
@@ -13,6 +13,7 @@ export default class PostmanSerializer extends BaseSerializer {
         this.references = null
         this.usedReferences = []
     }
+
     serialize(context) {
         let structure = this._formatStructure(context)
 

--- a/src/serializers/postman/Serializer.js
+++ b/src/serializers/postman/Serializer.js
@@ -344,9 +344,14 @@ export default class PostmanSerializer extends BaseSerializer {
         }
         else if (type === 'reference') {
             let ref = param.get('value')
-            let rawName = ref.get('relative') || ref.get('uri') || key
 
-            pair = '{{' + rawName.split('/').slice(-1)[0] + '}}'
+            if (this._isInlineRef(ref)) {
+                pair = param.generate()
+            }
+            else {
+                let rawName = ref.get('relative') || ref.get('uri') || key
+                pair = '{{' + rawName.split('/').slice(-1)[0] + '}}'
+            }
         }
         else {
             pair = '{{' + key + '}}'
@@ -355,7 +360,7 @@ export default class PostmanSerializer extends BaseSerializer {
         return {
             key: param.get('key'),
             value: pair,
-            type: param.get('type'),
+            type: 'text',
             enabled: true
         }
     }

--- a/src/serializers/swagger/Serializer.js
+++ b/src/serializers/swagger/Serializer.js
@@ -799,7 +799,7 @@ export default class SwaggerSerializer extends BaseSerializer {
         let scopeDescriptions = {}
         let security
         if (scopes) {
-            scopes = scopes.toJS()
+            scopes = Array.isArray(scopes) ? scopes : scopes.toJS()
             security = {
                 oauth_2_auth: scopes
             }


### PR DESCRIPTION
#### 7 fixes
- Fixed a bug where the Content-Type would not be taken into account when the body was not a url-encoded or multipart
- Paw parser now uses an Immutable.List for OAuth2 scopes - like they should be
- `let => const` for a bunch of expressions
- normalized the error thrown by the RAML loader in the RAML Parser (ScannerError were very verbose)
- fixed a bug where postman serializer would crash on local JSON Schemas (usually happened when converting from Swagger to Postman)
- fixed the postman serializer type to actually match the definition in the postman 1.0 schema
- Swagger serializer is now more tolerant towards OAuth2 scopes (can be Array or Immutable.List),. Although scopes should still be an Immutable.List, this should protect the serializer against poor implementations.