### PR TITLE
Postman Serializer - body generation issue & Internal Parser bug fixes

### DIFF
--- a/src/parsers/internal/Parser.js
+++ b/src/parsers/internal/Parser.js
@@ -111,7 +111,7 @@ export default class InternalParser {
                 ::this._extractMaximumPropertiesConstraint,
             'minimum-properties.constraint.models':
                 ::this._extractMinimumPropertiesConstraint,
-            'emum.constraint.models': ::this._extractEnumConstraint,
+            'enum.constraint.models': ::this._extractEnumConstraint,
             'reference-container.references.models':
                 ::this._extractReferenceContainer,
             'reference-cache.references.models':
@@ -299,7 +299,8 @@ export default class InternalParser {
 
         if (obj.internals) {
             obj.internals = new Immutable.List(obj.internals.map(internal => {
-                return this._extract(internal)
+                const _internal = this._extract(internal)
+                return _internal
             }))
         }
 

--- a/src/runners/base-runner.js
+++ b/src/runners/base-runner.js
@@ -133,7 +133,15 @@ export default class BaseFlow {
         })
     }
 
-    parse(item, opts) {
+    parse(item, _opts) {
+        let opts = null
+        if (_opts && typeof _opts.set === 'function') {
+            opts = _opts
+        }
+        else {
+            opts = new Options(_opts)
+        }
+
         const sourceFormat = opts.getIn([ 'parser', 'name' ])
         const sourceVersion = opts.getIn([ 'parser', 'version' ])
         const parsers = this.getParsers()
@@ -201,7 +209,7 @@ export default class BaseFlow {
 
     transform(input, _opts) {
         let opts = null
-        if (typeof _opts.set === 'function') {
+        if (_opts && typeof _opts.set === 'function') {
             opts = _opts
         }
         else {

--- a/src/runners/flow-web.js
+++ b/src/runners/flow-web.js
@@ -1,7 +1,8 @@
 import SwaggerParser from '../parsers/swagger/Parser'
 import RAMLParser from '../parsers/raml/Parser'
 import PostmanParser from '../parsers/postman/Parser'
-import CurlParser from '../parsers/curl/Parser'
+import CurlParser from '../parsers/cURL/Parser'
+import InternalParser from '../parsers/internal/Parser'
 
 import SwaggerSerializer from '../serializers/swagger/Serializer'
 import RAMLSerializer from '../serializers/raml/Serializer'
@@ -15,12 +16,13 @@ import BrowserEnvironment, {
 
 import BaseFlow from './base-runner'
 
-export default class FlowBrowser extends BaseFlow {
+export class FlowBrowser extends BaseFlow {
     static parsers = {
         swagger: SwaggerParser,
         raml: RAMLParser,
         postman: PostmanParser,
-        curl: CurlParser
+        curl: CurlParser,
+        __internal__: InternalParser
     }
 
     static serializers = {


### PR DESCRIPTION
### Postman Serializer
- improves postman serializers handling of headers (removes a `\nundefined` that appeared in some instances)
- improves handling of the body in the case where it is a JSONSchemaReference that's an inline reference, whose schema is of type `string` and has a `default` field. We now store the generated value of the schema (e.g. the `default` value), instead of the schema. Behavior fits better most cases.

### General
- **InternalParser:** fixed a typo for the internal parser
- **base-runner:** added a check for options in `parse` as this method is now public and can be used with a simple object instead of an `Options` immutable record.
- **flow-web:** added the internal parser and made FlowBrowser a non-default export so that it can be accessible from window via this name.