### PR TITLE
Add Names to Auths

### DIFF
--- a/src/models/Auth.js
+++ b/src/models/Auth.js
@@ -7,6 +7,7 @@ export class BasicAuth extends Immutable.Record({
         name: 'basic.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     username: null,
     password: null,
     raw: null
@@ -17,6 +18,7 @@ export class DigestAuth extends Immutable.Record({
         name: 'digest.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     username: null,
     password: null
 }) { }
@@ -26,6 +28,7 @@ export class NTLMAuth extends Immutable.Record({
         name: 'ntlm.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     username: null,
     password: null
 }) { }
@@ -35,6 +38,7 @@ export class NegotiateAuth extends Immutable.Record({
         name: 'negotiate.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     username: null,
     password: null
 }) { }
@@ -44,6 +48,7 @@ export class ApiKeyAuth extends Immutable.Record({
         name: 'api-key.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     name: null,
     in: null,
     key: null
@@ -54,6 +59,7 @@ export class OAuth1Auth extends Immutable.Record({
         name: 'oauth-1.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     callback: null,
     consumerSecret: null,
     tokenSecret: null,
@@ -75,6 +81,7 @@ export class OAuth2Auth extends Immutable.Record({
         name: 'oauth-2.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     flow: null,
     authorizationUrl: null,
     tokenUrl: null,
@@ -86,6 +93,7 @@ export class AWSSig4Auth extends Immutable.Record({
         name: 'aws-sig-4.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     key: null,
     secret: null,
     region: null,
@@ -97,6 +105,7 @@ export class HawkAuth extends Immutable.Record({
         name: 'hawk.auth.models',
         version: '0.1.0'
     }),
+    authName: null,
     id: null,
     key: null,
     algorithm: null

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -718,7 +718,8 @@ export default class RAMLParser {
 
             for (let scheme of raml.securitySchemes || []) {
                 if (Object.keys(scheme)[0] === securedName) {
-                    let security = scheme[Object.keys(scheme)[0]]
+                    const authName = Object.keys(scheme)[0]
+                    let security = scheme[authName]
 
                     let securityMap = {
                         'OAuth 2.0': this._extractOAuth2Auth,
@@ -729,7 +730,9 @@ export default class RAMLParser {
 
                     let rule = securityMap[security.type]
                     if (rule) {
-                        auths = auths.push(rule(raml, security, params))
+                        auths = auths.push(
+                          rule(raml, authName, security, params)
+                        )
                     }
                 }
             }
@@ -737,7 +740,7 @@ export default class RAMLParser {
         return auths
     }
 
-    _extractOAuth2Auth(raml, security, params) {
+    _extractOAuth2Auth(raml, authName = null, security, params) {
         let flowMap = {
             code: 'accessCode',
             token: 'implicit',
@@ -746,6 +749,7 @@ export default class RAMLParser {
         }
         let _params = params || {}
         let auth = new Auth.OAuth2({
+            authName,
             flow:
                 flowMap[(_params.authorizationGrants || [])[0]] ||
                 flowMap[security.settings.authorizationGrants[0]] ||
@@ -768,9 +772,10 @@ export default class RAMLParser {
         return auth
     }
 
-    _extractOAuth1Auth(raml, security, params) {
+    _extractOAuth1Auth(raml, authName = null, security, params) {
         let _params = params || {}
         let auth = new Auth.OAuth1({
+            authName,
             authorizationUri:
                 _params.authorizationUri ||
                 security.settings.authorizationUri ||
@@ -788,13 +793,13 @@ export default class RAMLParser {
         return auth
     }
 
-    _extractBasicAuth() {
-        let auth = new Auth.Basic()
+    _extractBasicAuth(raml, authName = null) {
+        let auth = new Auth.Basic({ authName })
         return auth
     }
 
-    _extractDigestAuth() {
-        let auth = new Auth.Digest()
+    _extractDigestAuth(raml, authName = null) {
+        let auth = new Auth.Digest({ authName })
         return auth
     }
 

--- a/src/parsers/raml/v0.8/__tests__/Parser-test.js
+++ b/src/parsers/raml/v0.8/__tests__/Parser-test.js
@@ -1172,6 +1172,7 @@ export class TestRAMLParser extends UnitTest {
             parser.spy._extractOAuth2Auth.calls[0],
             [
                 raml,
+                'oauth_2_0',
                 scheme,
                 {
                     scopes: [
@@ -1334,13 +1335,16 @@ export class TestRAMLParser extends UnitTest {
         }
 
         const expected = new Auth.OAuth2({
+            authName: 'oauth_2_0',
             flow: 'accessCode',
             authorizationUrl: 'https://www.box.com/api/oauth2/authorize',
             tokenUrl: 'https://www.box.com/api/oauth2/token',
             scopes: new Immutable.List(params.scopes)
         })
 
-        const result = parser._extractOAuth2Auth(raml, scheme, params)
+        const result = parser._extractOAuth2Auth(
+          raml, 'oauth_2_0', scheme, params
+        )
 
         this.assertEqual(expected, result)
     }
@@ -1359,12 +1363,13 @@ export class TestRAMLParser extends UnitTest {
         }
 
         const expected = new Auth.OAuth1({
+            authName: 'oauth_1_0',
             authorizationUri: 'https://www.box.com/api/oauth1/authorize',
             requestTokenUri: 'https://www.box.com/api/oauth1/request',
             tokenCredentialsUri: 'https://www.box.com/api/oauth1/token'
         })
 
-        const result = parser._extractOAuth1Auth(raml, scheme)
+        const result = parser._extractOAuth1Auth(raml, 'oauth_1_0', scheme)
 
         this.assertEqual(expected, result)
     }

--- a/src/parsers/swagger/v2.0/Parser.js
+++ b/src/parsers/swagger/v2.0/Parser.js
@@ -299,8 +299,9 @@ export default class SwaggerParser {
                         'scopes', new Immutable.List(security[key])
                     )
 
-                    if (typeMap[definition.get('type')]) {
-                        let auth = typeMap[definition.get('type')](definition)
+                    const type = definition.get('type')
+                    if (typeMap[type]) {
+                        let auth = typeMap[type](key, definition)
                         auths.push(auth)
                     }
                 }
@@ -311,7 +312,7 @@ export default class SwaggerParser {
         return _request.set('auths', auths)
     }
 
-    _setBasicAuth(definition) {
+    _setBasicAuth(authName = null, definition) {
         let username = null
         let password = null
 
@@ -320,21 +321,20 @@ export default class SwaggerParser {
             password = definition['x-password'] || null
         }
 
-        return new Auth.Basic({
-            username: username,
-            password: password
-        })
+        return new Auth.Basic({ authName, username, password })
     }
 
-    _setApiKeyAuth(definition) {
+    _setApiKeyAuth(authName = null, definition) {
         return new Auth.ApiKey({
+            authName,
             in: definition.get('in'),
             name: definition.get('name')
         })
     }
 
-    _setOAuth2Auth(definition) {
+    _setOAuth2Auth(authName = null, definition) {
         return new Auth.OAuth2({
+            authName,
             flow: definition.get('flow', null),
             authorizationUrl: definition.get('authorizationUrl', null),
             tokenUrl: definition.get('tokenUrl', null),

--- a/src/parsers/swagger/v2.0/__tests__/Parser-test.js
+++ b/src/parsers/swagger/v2.0/__tests__/Parser-test.js
@@ -978,11 +978,12 @@ export class TestSwaggerParser extends UnitTest {
         })
 
         const expected = new Auth.ApiKey({
+            authName: 'api_key',
             in: 'header',
             name: 'api-key'
         })
 
-        const result = parser._setApiKeyAuth(input)
+        const result = parser._setApiKeyAuth('api_key', input)
 
         this.assertEqual(expected, result)
     }
@@ -999,13 +1000,14 @@ export class TestSwaggerParser extends UnitTest {
         })
 
         const expected = new Auth.OAuth2({
+            authName: 'petstore_auth',
             flow: 'implicit',
             authorizationUrl: 'fakeurl.com/auth',
             tokenUrl: 'fakeurl.com/token',
             scopes: new Immutable.List([ 'read:any', 'write:own' ])
         })
 
-        const result = parser._setOAuth2Auth(input)
+        const result = parser._setOAuth2Auth('petstore_auth', input)
 
         this.assertEqual(expected, result)
     }

--- a/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
+++ b/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
@@ -1261,7 +1261,9 @@ export default class SwaggerFixtures {
                     }
                 ],
                 output: new Request({
-                    auths: new Immutable.List([ new Auth.Basic({ authName: 'basicAuth' }) ])
+                    auths: new Immutable.List([
+                        new Auth.Basic({ authName: 'basicAuth' })
+                    ])
                 })
             },
             {

--- a/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
+++ b/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
@@ -1261,7 +1261,7 @@ export default class SwaggerFixtures {
                     }
                 ],
                 output: new Request({
-                    auths: new Immutable.List([ new Auth.Basic() ])
+                    auths: new Immutable.List([ new Auth.Basic({ authName: 'basicAuth' }) ])
                 })
             },
             {
@@ -1288,6 +1288,7 @@ export default class SwaggerFixtures {
                 output: new Request({
                     auths: new Immutable.List([
                         new Auth.ApiKey({
+                            authName: 'api_key',
                             name: 'api_key',
                             in: 'header'
                         })
@@ -1325,6 +1326,7 @@ export default class SwaggerFixtures {
                 output: new Request({
                     auths: new Immutable.List([
                         new Auth.OAuth2({
+                            authName: 'petstore_auth',
                             flow: 'implicit',
                             authorizationUrl: 'http://s.com/oauth',
                             scopes: new Immutable.List(
@@ -1364,8 +1366,9 @@ export default class SwaggerFixtures {
                 ],
                 output: new Request({
                     auths: new Immutable.List([
-                        new Auth.Basic(),
+                        new Auth.Basic({ authName: 'basicAuth' }),
                         new Auth.ApiKey({
+                            authName: 'api_key',
                             name: 'api_key',
                             in: 'header'
                         })

--- a/src/resolvers/__tests__/ParameterResolver-test.js
+++ b/src/resolvers/__tests__/ParameterResolver-test.js
@@ -1367,7 +1367,7 @@ export class TestParameterResolver extends UnitTest {
 
         resolver._updateAuths(auths, null)
 
-        this.assertEqual(resolver.spy._getValueFromKey.count, 7)
+        this.assertEqual(resolver.spy._getValueFromKey.count, 9)
     }
 
     @targets('_updateAuths')
@@ -1395,10 +1395,11 @@ export class TestParameterResolver extends UnitTest {
         const expected = new Immutable.List([
             new Auth.Basic({
                 _model: 12,
-                password: 12
+                username: 12,
+                raw: 12
             }),
             new Auth.Digest({
-                _model: 12,
+                authName: 12,
                 password: 12
             })
         ])


### PR DESCRIPTION
- adds `authName` to auth model
- adds auth naming support to swagger parser
- adds auth naming support to raml parser