### PR TITLE
097 separate groups from requests

### DIFF
--- a/src/models/Auth.js
+++ b/src/models/Auth.js
@@ -7,6 +7,7 @@ export class BasicAuth extends Immutable.Record({
         name: 'basic.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     username: null,
     password: null,
@@ -18,6 +19,7 @@ export class DigestAuth extends Immutable.Record({
         name: 'digest.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     username: null,
     password: null
@@ -28,6 +30,7 @@ export class NTLMAuth extends Immutable.Record({
         name: 'ntlm.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     username: null,
     password: null
@@ -38,6 +41,7 @@ export class NegotiateAuth extends Immutable.Record({
         name: 'negotiate.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     username: null,
     password: null
@@ -48,6 +52,7 @@ export class ApiKeyAuth extends Immutable.Record({
         name: 'api-key.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     name: null,
     in: null,
@@ -59,6 +64,7 @@ export class OAuth1Auth extends Immutable.Record({
         name: 'oauth-1.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     callback: null,
     consumerSecret: null,
@@ -81,6 +87,7 @@ export class OAuth2Auth extends Immutable.Record({
         name: 'oauth-2.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     flow: null,
     authorizationUrl: null,
@@ -93,6 +100,7 @@ export class AWSSig4Auth extends Immutable.Record({
         name: 'aws-sig-4.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     key: null,
     secret: null,
@@ -105,6 +113,7 @@ export class HawkAuth extends Immutable.Record({
         name: 'hawk.auth.models',
         version: '0.1.0'
     }),
+    description: null,
     authName: null,
     id: null,
     key: null,

--- a/src/models/Core.js
+++ b/src/models/Core.js
@@ -387,6 +387,7 @@ export default class Context extends Immutable.Record({
         name: 'context.core.models',
         version: '0.1.0'
     }),
+    requests: new Immutable.OrderedMap(),
     group: null,
     references: new Immutable.OrderedMap(),
     info: new Info()

--- a/src/parsers/cURL/Parser.js
+++ b/src/parsers/cURL/Parser.js
@@ -119,13 +119,21 @@ export default class CurlParser {
         // parse
         this.idx = 0
 
-        this.context = this.context.set(
-            'group',
-            new Group({
-                name: 'cURL Imports',
-                children: this._parseAll()
-            })
+        let requests = this._parseAll()
+        let group = new Group({
+            name: 'cURL Imports',
+            children: requests.reduce(
+                (acc, val, index) => acc.set(index, index),
+                new Immutable.OrderedMap()
+            )
+        })
+        const requestMap = requests.reduce(
+            (acc, val, index) => acc.set(index, val),
+            new Immutable.OrderedMap()
         )
+        this.context = this.context
+            .set('group', group)
+            .set('requests', requestMap)
 
         return this.context
     }

--- a/src/parsers/cURL/__tests__/Parser-test.js
+++ b/src/parsers/cURL/__tests__/Parser-test.js
@@ -4239,17 +4239,30 @@ export class TestCurlParser extends UnitTest {
         let context = parser.parse({
             content: input
         })
-        let requests = context.getIn([ 'group', 'children' ])
+
+        let groupMap = context.getIn([ 'group', 'children' ])
+        let requestMap = context.get('requests')
 
         // remove bodyString from request if we don't want to compare it here
 
+        const expectedGroupMap = expected.reduce(
+            (acc, val, index) => acc.set(index, index),
+            new Immutable.OrderedMap()
+        )
+
+        const expectedRequestMap = expected.reduce(
+            (acc, val, index) => acc.set(index, val),
+            new Immutable.OrderedMap()
+        )
+
         /* eslint-disable  no-console */
         if (verbose) {
-            console.log(requests)
-            console.log(expected)
+            console.log(requestMap)
+            console.log(expectedRequestMap)
         }
         /* eslint-enable  no-console */
 
-        this.assertJSONEqual(requests, expected)
+        this.assertJSONEqual(groupMap, expectedGroupMap)
+        this.assertJSONEqual(requestMap, expectedRequestMap)
     }
 }

--- a/src/parsers/internal/Parser.js
+++ b/src/parsers/internal/Parser.js
@@ -160,6 +160,7 @@ export default class InternalParser {
 
     _extractContext(obj) {
         let references = {}
+        let requests = {}
 
         if (obj.references) {
             let refs = Object.keys(obj.references || {})
@@ -168,7 +169,15 @@ export default class InternalParser {
             }
         }
 
+        if (obj.requests) {
+            let reqs = Object.keys(obj.requests || {})
+            for (let req of reqs) {
+                requests[req] = this._extract(obj.requests[req])
+            }
+        }
+
         const context = new Context({
+            requests: new Immutable.OrderedMap(requests),
             group: this._extract(obj.group),
             references: new Immutable.OrderedMap(references),
             info: this._extract(obj.info)

--- a/src/parsers/internal/Parser.js
+++ b/src/parsers/internal/Parser.js
@@ -155,6 +155,27 @@ export default class InternalParser {
             return classMap[obj._model.name](obj)
         }
 
+        const _obj = this._traverse(obj)
+        return _obj
+    }
+
+    _traverse(_obj) {
+        let obj = _obj
+        if (!obj) {
+            return obj
+        }
+
+        if (typeof obj === 'object') {
+            const keys = Object.keys(obj || {})
+            for (let key of keys) {
+                obj[key] = this._extract(obj[key])
+            }
+        }
+
+        if (Array.isArray(obj)) {
+            obj = obj.map(item => this._extract(item))
+        }
+
         return obj
     }
 
@@ -468,12 +489,14 @@ export default class InternalParser {
     _extractReferenceCache(_obj) {
         let obj = _obj
 
-        const resolved = {}
         if (obj.resolved) {
+            const resolved = {}
             let keys = Object.keys(obj.resolved)
             for (let key of keys) {
                 resolved[key] = this._extract(obj.resolved[key])
             }
+
+            obj.resolved = new Immutable.OrderedMap(resolved)
         }
 
         if (obj.cached) {
@@ -486,8 +509,12 @@ export default class InternalParser {
     _extractReference(_obj) {
         let obj = _obj
         if (obj.dependencies) {
-            obj.dependencies = new Immutable.List(obj.dependencies)
+            obj.dependencies = new Immutable.List(
+                obj.dependencies.map(dep => this._extract(dep))
+            )
         }
+
+        obj.value = this._extract(obj.value)
 
         return new Reference(obj)
     }
@@ -495,24 +522,38 @@ export default class InternalParser {
     _extractExoticReference(_obj) {
         let obj = _obj
         if (obj.dependencies) {
-            obj.dependencies = new Immutable.List(obj.dependencies)
+            obj.dependencies = new Immutable.List(
+                obj.dependencies.map(dep => this._extract(dep))
+            )
         }
+
+        obj.value = this._extract(obj.value)
+
         return new ExoticReference(obj)
     }
 
     _extractJSONSchemaReference(_obj) {
         let obj = _obj
         if (obj.dependencies) {
-            obj.dependencies = new Immutable.List(obj.dependencies)
+            obj.dependencies = new Immutable.List(
+                obj.dependencies.map(dep => this._extract(dep))
+            )
         }
+
+        obj.value = this._extract(obj.value)
+
         return new JSONSchemaReference(obj)
     }
 
     _extractLateResolutionReference(_obj) {
         let obj = _obj
         if (obj.dependencies) {
-            obj.dependencies = new Immutable.List(obj.dependencies)
+            obj.dependencies = new Immutable.List(
+                obj.dependencies.map(dep => this._extract(dep))
+            )
         }
+
+        obj.value = this._extract(obj.value)
 
         return new LateResolutionReference(obj)
     }

--- a/src/parsers/paw/__tests__/Parser-test.js
+++ b/src/parsers/paw/__tests__/Parser-test.js
@@ -45,7 +45,7 @@ export class TestPawParser extends UnitTest {
         const paw = this.__init()
 
         paw.spyOn('_parseGroup', () => {
-            return null
+            return { group: null, requests: null }
         })
 
         paw.spyOn('_parseDomains', () => {
@@ -66,7 +66,7 @@ export class TestPawParser extends UnitTest {
         const paw = this.__init()
 
         paw.spyOn('_parseGroup', () => {
-            return null
+            return { group: null, requests: null }
         })
 
         paw.spyOn('_parseDomains', () => {
@@ -87,7 +87,7 @@ export class TestPawParser extends UnitTest {
         const paw = this.__init()
 
         paw.spyOn('_parseGroup', () => {
-            return null
+            return { group: null, requests: null }
         })
 
         paw.spyOn('_parseDomains', () => {
@@ -108,7 +108,7 @@ export class TestPawParser extends UnitTest {
         const paw = this.__init()
 
         paw.spyOn('_parseGroup', () => {
-            return 12
+            return { group: 12, requests: { a: 90 } }
         })
 
         paw.spyOn('_parseDomains', () => {
@@ -120,6 +120,7 @@ export class TestPawParser extends UnitTest {
         })
 
         const expected = new Context({
+            requests: new Immutable.OrderedMap({ a: 90 }),
             group: 12,
             references: 42,
             info: 90
@@ -134,7 +135,7 @@ export class TestPawParser extends UnitTest {
     testParseGroupReturnsNullIfNoRequests() {
         const [ paw, ctx ] = this.__init(2)
 
-        const expected = null
+        const expected = { group: null, requests: {} }
         const result = paw._parseGroup(ctx, [])
 
         this.assertEqual(expected, result)
@@ -196,26 +197,34 @@ export class TestPawParser extends UnitTest {
             }
         ]
 
-        const expected = new Group({
-            children: new Immutable.OrderedMap({
-                4567: 12,
-                42: new Group({
-                    id: '42',
-                    name: 'group#1',
-                    children: new Immutable.OrderedMap({
-                        1234: 12,
-                        2345: 12
-                    })
-                }),
-                90: new Group({
-                    id: '90',
-                    name: 'group#2',
-                    children: new Immutable.OrderedMap({
-                        3456: 12
+        const expected = {
+            group: new Group({
+                children: new Immutable.OrderedMap({
+                    4567: '4567',
+                    42: new Group({
+                        id: '42',
+                        name: 'group#1',
+                        children: new Immutable.OrderedMap({
+                            1234: '1234',
+                            2345: '2345'
+                        })
+                    }),
+                    90: new Group({
+                        id: '90',
+                        name: 'group#2',
+                        children: new Immutable.OrderedMap({
+                            3456: '3456'
+                        })
                     })
                 })
-            })
-        })
+            }),
+            requests: {
+                1234: 12,
+                2345: 12,
+                3456: 12,
+                4567: 12
+            }
+        }
 
         const result = paw._parseGroup(ctx, input)
 
@@ -274,26 +283,34 @@ export class TestPawParser extends UnitTest {
             }
         ]
 
-        const expected = new Group({
-            children: new Immutable.OrderedMap({
-                4567: 12,
-                90: new Group({
-                    id: '90',
-                    name: 'group#2',
-                    children: new Immutable.OrderedMap({
-                        3456: 12,
-                        42: new Group({
-                            id: '42',
-                            name: 'group#1',
-                            children: new Immutable.OrderedMap({
-                                1234: 12,
-                                2345: 12
+        const expected = {
+            group: new Group({
+                children: new Immutable.OrderedMap({
+                    4567: '4567',
+                    90: new Group({
+                        id: '90',
+                        name: 'group#2',
+                        children: new Immutable.OrderedMap({
+                            3456: '3456',
+                            42: new Group({
+                                id: '42',
+                                name: 'group#1',
+                                children: new Immutable.OrderedMap({
+                                    1234: '1234',
+                                    2345: '2345'
+                                })
                             })
                         })
                     })
                 })
-            })
-        })
+            }),
+            requests: {
+                1234: 12,
+                2345: 12,
+                3456: 12,
+                4567: 12
+            }
+        }
 
         const result = paw._parseGroup(ctx, input)
 

--- a/src/parsers/postman/v1/Parser.js
+++ b/src/parsers/postman/v1/Parser.js
@@ -155,9 +155,13 @@ export default class PostmanParser {
             let env = this._importEnvironment(_env)
             envs = envs.set(env.get('id'), env)
         })
+
+        let _requests = {}
         let baseGroup = collections.reduce(
             (rootGroup, collection) => {
-                let group = this._importCollection(collection)
+                let { group, requests } = this._importCollection(collection)
+                Object.assign(_requests, requests)
+
                 return rootGroup.setIn(
                     [ 'children', group.get('id') ], group
                 )
@@ -235,9 +239,11 @@ export default class PostmanParser {
             requestsById[req.id] = request
         }
 
-        return this._createGroupFromCollection(
+        const group = this._createGroupFromCollection(
             collection, requestsById
         )
+
+        return { group, requests: requestsById }
     }
 
     // @tested
@@ -739,7 +745,7 @@ export default class PostmanParser {
                     [
                         'children', req.get('id')
                     ],
-                    req
+                    req.get('id')
                 )
             }
         }
@@ -775,7 +781,7 @@ export default class PostmanParser {
                 for (let id of collection.order) {
                     let req = requests[id]
                     rootGroup = rootGroup
-                        .setIn([ 'children', req.get('id') ], req)
+                        .setIn([ 'children', req.get('id') ], req.get('id'))
                 }
             }
         }
@@ -784,7 +790,7 @@ export default class PostmanParser {
                 if (requests.hasOwnProperty(id)) {
                     let req = requests[id]
                     rootGroup = rootGroup
-                        .setIn([ 'children', req.get('id') ], req)
+                        .setIn([ 'children', req.get('id') ], req.get('id'))
                 }
             }
         }

--- a/src/parsers/postman/v1/__tests__/Parser-test.js
+++ b/src/parsers/postman/v1/__tests__/Parser-test.js
@@ -126,7 +126,7 @@ export class TestPostmanParser extends UnitTest {
         const colls = [ { get: () => {} }, { get: () => {} } ]
 
         mp.spyOn('_importCollection', (obj) => {
-            return obj
+            return { group: obj, requests: obj }
         })
 
         parser._createContext.apply(
@@ -159,7 +159,7 @@ export class TestPostmanParser extends UnitTest {
         })
 
         mp.spyOn('_importCollection', (obj) => {
-            return obj
+            return { group: obj, requests: obj }
         })
 
         const result = parser._createContext.apply(
@@ -270,21 +270,30 @@ export class TestPostmanParser extends UnitTest {
 
         const coll = {
             requests: [
-                {}
+                {
+                    id: 42
+                }
             ]
         }
 
-        mp.spyOn('_createRequest', () => {})
+        mp.spyOn('_createRequest', () => null)
         mp.spyOn('_createGroupFromCollection', () => {
             return 12
         })
+
+        const expected = {
+            group: 12,
+            requests: {
+                42: null
+            }
+        }
 
         const result = parser._importCollection.apply(
             mp,
             [ coll ]
         )
 
-        this.assertEqual(result, 12)
+        this.assertEqual(result, expected)
 
         this.assertEqual(
             mp.spy._createRequest.count, 1
@@ -1905,14 +1914,8 @@ export class TestPostmanParser extends UnitTest {
         const expected = new Group({
             name: 'hello',
             children: new Immutable.OrderedMap({
-                0: new Request({
-                    id: 0,
-                    method: 'get'
-                }),
-                1: new Request({
-                    id: 1,
-                    method: 'post'
-                })
+                0: 0,
+                1: 1
             })
         })
 
@@ -1945,10 +1948,7 @@ export class TestPostmanParser extends UnitTest {
         const expected = new Group({
             name: 'hello',
             children: new Immutable.OrderedMap({
-                0: new Request({
-                    id: 0,
-                    method: 'get'
-                })
+                0: 0
             })
         })
 
@@ -1981,10 +1981,7 @@ export class TestPostmanParser extends UnitTest {
         const expected = new Group({
             name: 'hello',
             children: new Immutable.OrderedMap({
-                0: new Request({
-                    id: 0,
-                    method: 'get'
-                })
+                0: 0
             })
         })
 
@@ -2017,14 +2014,8 @@ export class TestPostmanParser extends UnitTest {
             id: 0,
             name: 'collection name',
             children: new Immutable.OrderedMap({
-                0: new Request({
-                    id: 0,
-                    method: 'get'
-                }),
-                1: new Request({
-                    id: 1,
-                    method: 'post'
-                })
+                0: 0,
+                1: 1
             })
         })
 
@@ -2058,14 +2049,8 @@ export class TestPostmanParser extends UnitTest {
             id: 0,
             name: 'collection name',
             children: new Immutable.OrderedMap({
-                1: new Request({
-                    id: 1,
-                    method: 'post'
-                }),
-                0: new Request({
-                    id: 0,
-                    method: 'get'
-                })
+                1: 1,
+                0: 0
             })
         })
 
@@ -2114,20 +2099,14 @@ export class TestPostmanParser extends UnitTest {
                     id: 12,
                     name: 'folder #12',
                     children: new Immutable.OrderedMap({
-                        0: new Request({
-                            id: 0,
-                            method: 'get'
-                        })
+                        0: 0
                     })
                 }),
                 42: new Group({
                     id: 42,
                     name: 'folder #42',
                     children: new Immutable.OrderedMap({
-                        1: new Request({
-                            id: 1,
-                            method: 'post'
-                        })
+                        1: 1
                     })
                 })
             })

--- a/src/parsers/raml/resolvers/FileResolver.js
+++ b/src/parsers/raml/resolvers/FileResolver.js
@@ -1,0 +1,30 @@
+import path from 'path-browserify'
+
+export default class ShimmingFileResolver {
+    constructor(items) {
+        this.baseItem = ''
+        this.items = items || []
+    }
+
+    readFileAsync(filePath) {
+        for (let item of this.items) {
+            if (filePath.indexOf(
+                path.join(item.file.path, item.file.name)
+            ) === 0) {
+                return new Promise((resolve) => {
+                    resolve(item.content)
+                })
+            }
+        }
+        return new Promise((resolve) => {
+            resolve(
+                '::fileRef::' +
+                path.relative(path.dirname(this.baseItem), filePath)
+            )
+        })
+    }
+
+    setBaseItem(item) {
+        this.baseItem = item.getPath()
+    }
+}

--- a/src/parsers/raml/resolvers/HttpResolver.js
+++ b/src/parsers/raml/resolvers/HttpResolver.js
@@ -1,0 +1,30 @@
+import path from 'path-browserify'
+
+export default class ShimmingHttpResolver {
+    constructor(items) {
+        this.baseItem = ''
+        this.items = items || []
+    }
+
+    readFileAsync(filePath) {
+        for (let item of this.items) {
+            if (filePath.indexOf(
+                path.join(item.file.path, item.file.name)
+            ) === 0) {
+                return new Promise((resolve) => {
+                    resolve(item.content)
+                })
+            }
+        }
+        return new Promise((resolve) => {
+            resolve(
+                '::fileRef::' +
+                path.relative(path.dirname(this.baseItem), filePath)
+            )
+        })
+    }
+
+    setBaseItem(item) {
+        this.baseItem = item.getPath()
+    }
+}

--- a/src/parsers/raml/resolvers/__tests__/FileResolver-test.js
+++ b/src/parsers/raml/resolvers/__tests__/FileResolver-test.js
@@ -1,0 +1,61 @@
+import { UnitTest, registerTest } from '../../../../utils/TestUtils'
+
+import ShimmingFileReader from '../FileResolver'
+
+@registerTest
+export class TestFileReader extends UnitTest {
+    testConstructor() {
+        let items = [ 1, 2, 3, 'test' ]
+
+        let reader = new ShimmingFileReader(items)
+        this.assertEqual(reader.items, items)
+    }
+
+    testReadFileAsyncWithSimpleFile() {
+        const items = [
+            {
+                content: 'Lorem Ipsum dolor sic amet',
+                file: {
+                    path: '/some/path',
+                    name: 'simpleFile'
+                }
+            }
+        ]
+
+        let reader = new ShimmingFileReader(items)
+
+        reader.readFileAsync('/some/path/simpleFile').then(
+            data => {
+                this.assertEqual(items[0].content, data)
+            }
+        ).catch(
+            () => {
+                this.assertTrue(false)
+            }
+        )
+    }
+
+    testReadFileAsyncWithMissingFile() {
+        const items = [
+            {
+                content: 'Lorem Ipsum dolor sic amet',
+                file: {
+                    path: '/some/path',
+                    name: 'simpleFile'
+                }
+            }
+        ]
+
+        let reader = new ShimmingFileReader(items)
+
+        reader.readFileAsync('/some/path/missingFile').then(
+            data => {
+                this.assertEqual(data, '::fileRef::/some/path/missingFile')
+            }
+        ).catch(
+            () => {
+                this.assertTrue(false)
+            }
+        )
+    }
+}

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -767,6 +767,7 @@ export default class RAMLParser {
         let _params = params || {}
         let auth = new Auth.OAuth2({
             authName,
+            description: security.description || null,
             flow:
                 flowMap[(_params.authorizationGrants || [])[0]] ||
                 flowMap[security.settings.authorizationGrants[0]] ||
@@ -793,6 +794,7 @@ export default class RAMLParser {
         let _params = params || {}
         let auth = new Auth.OAuth1({
             authName,
+            description: security.description || null,
             authorizationUri:
                 _params.authorizationUri ||
                 security.settings.authorizationUri ||
@@ -810,13 +812,19 @@ export default class RAMLParser {
         return auth
     }
 
-    _extractBasicAuth(raml, authName = null) {
-        let auth = new Auth.Basic({ authName })
+    _extractBasicAuth(raml, authName = null, security = {}) {
+        let auth = new Auth.Basic({
+            authName,
+            description: security.description || null
+        })
         return auth
     }
 
-    _extractDigestAuth(raml, authName = null) {
-        let auth = new Auth.Digest({ authName })
+    _extractDigestAuth(raml, authName = null, security = {}) {
+        let auth = new Auth.Digest({
+            authName,
+            description: security.description || null
+        })
         return auth
     }
 

--- a/src/parsers/raml/v0.8/__tests__/Parser-test.js
+++ b/src/parsers/raml/v0.8/__tests__/Parser-test.js
@@ -1354,6 +1354,9 @@ export class TestRAMLParser extends UnitTest {
 
         const expected = new Auth.OAuth2({
             authName: 'oauth_2_0',
+            description: 'The Box API uses OAuth 2 for authentication. ' +
+                'An authorization header containing\na valid access_token ' +
+                'must be included in every request.\n',
             flow: 'accessCode',
             authorizationUrl: 'https://www.box.com/api/oauth2/authorize',
             tokenUrl: 'https://www.box.com/api/oauth2/token',

--- a/src/parsers/raml/v0.8/__tests__/Parser-test.js
+++ b/src/parsers/raml/v0.8/__tests__/Parser-test.js
@@ -404,7 +404,7 @@ export class TestRAMLParser extends UnitTest {
         let mockedParser = new ClassMock(parser, '')
 
         mockedParser.spyOn('_createGroupTree', () => {
-            return 12
+            return { group: 12, requests: { a: 42 } }
         })
 
         mockedParser.spyOn('_extractInfos', () => {
@@ -412,6 +412,7 @@ export class TestRAMLParser extends UnitTest {
         })
 
         const expected = new Context({
+            requests: new Immutable.OrderedMap({ a: 42 }),
             group: 12,
             info: 90
         })
@@ -422,6 +423,18 @@ export class TestRAMLParser extends UnitTest {
         )
 
         this.assertEqual(result, expected)
+    }
+
+    @targets('_uuid')
+    testUUIDisv4() {
+        const parser = new RAMLParser()
+
+        /* eslint-disable max-len */
+        const expectedPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+        /* eslint-enable max-len */
+
+        const result = parser._uuid()
+        this.assertTrue(!!result.match(expectedPattern))
     }
 
     @targets('_createGroupTree')
@@ -440,12 +453,17 @@ export class TestRAMLParser extends UnitTest {
             return 12
         })
 
-        let result = parser._createGroupTree.apply(
+        const expected = {
+            group: null,
+            requests: {}
+        }
+
+        const result = parser._createGroupTree.apply(
             mockedParser,
             [ raml, raml, raml.title ]
         )
 
-        this.assertNull(result)
+        this.assertEqual(result, expected)
     }
 
     @targets('_createGroupTree')

--- a/src/parsers/raml/v1.0/Parser.js
+++ b/src/parsers/raml/v1.0/Parser.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import RAML from 'raml-parser'
+import RAML from 'raml-1-parser'
 import __path from 'path'
 
 import Context, {
@@ -24,11 +24,12 @@ import JSONSchemaReference from '../../../models/references/JSONSchema'
 import Constraint from '../../../models/Constraint'
 import Auth from '../../../models/Auth'
 
-import ShimmingFileReader from '../FileReader'
+import ShimmingFileResolver from '../resolvers/FileResolver'
+import ShimmingHttpResolver from '../resolvers/HttpResolver'
 
 export default class RAMLParser {
     static format = 'raml'
-    static version = 'v0.8'
+    static version = 'v1.0'
 
     static detect(content) {
         let detection = {
@@ -38,7 +39,7 @@ export default class RAMLParser {
         }
 
         let firstLine = content.split('\n', 1)[0]
-        let match = firstLine.match(/#%RAML (0\.8|1\.0)/)
+        let match = firstLine.match(/#%RAML 1\.0/)
         if (match) {
             detection.score = 1
             return [ detection ]
@@ -56,7 +57,8 @@ export default class RAMLParser {
     }
 
     constructor(items) {
-        this.reader = new ShimmingFileReader(items)
+        this.fsResolver = new ShimmingFileResolver(items)
+        this.httpResolver = new ShimmingHttpResolver(items)
         this.context = new Context()
         this.item = new Item()
     }
@@ -76,7 +78,8 @@ export default class RAMLParser {
         let location = this.item.getPath()
 
         return RAML.load(string, location, {
-            reader: this.reader
+            fsResolver: this.fsResolver,
+            httpResolver: this.httpResolver
         }).then(raml => {
             if (raml) {
                 let context = this._createContext(raml)
@@ -93,32 +96,34 @@ export default class RAMLParser {
     }
 
     _createContext(_raml) {
-        const references = ::this._findReferences(_raml)
-        const raml = ::this._replaceReferences(_raml)
+        let context = new Context()
 
-        const { group, requests } = this._createGroupTree(
+        let references = ::this._findReferences(_raml)
+        let raml = ::this._replaceReferences(_raml)
+
+        let group = this._createGroupTree(
             raml,
             raml,
             raml.title || null
         )
 
-        let referenceMap = new Immutable.OrderedMap()
+        if (group) {
+            context = context.set('group', group)
+        }
+
         if (references) {
             let container = new ReferenceContainer()
             container = container.create(references)
             if (container.get('cache').size > 0) {
-                referenceMap = referenceMap.set(raml.title, container)
+                context = context.setIn([ 'references', raml.title ], container)
             }
         }
 
-        const info = this._extractInfos(_raml)
+        let info = this._extractInfos(_raml)
 
-        const context = new Context({
-            requests: new Immutable.OrderedMap(requests),
-            group: group,
-            references: referenceMap,
-            info: info ? info : new Info()
-        })
+        if (info) {
+            context = context.set('info', info)
+        }
 
         return context
     }
@@ -254,61 +259,42 @@ export default class RAMLParser {
         return obj
     }
 
-    _uuid() {
-        let d = new Date().getTime()
-        let uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-            .replace(/[xy]/g, c => {
-                let r = (d + Math.random() * 16) % 16 | 0
-                d = Math.floor(d / 16)
-                return (c === 'x' ? r : r & 0x3 | 0x8).toString(16)
-            })
-        return uuid
-    }
-
     _createGroupTree(baseTree, tree, baseName, url = '') {
         let _url = url
         // ignore the first group name
         _url += tree.relativeUri || ''
 
-        let _group
-        let _requests = {}
+        let group
         if (tree.resources || tree.methods) {
-            _group = new Group({
+            group = new Group({
                 name: tree.displayName || tree.relativeUri || baseName
             })
         }
 
         for (let path of tree.resources || []) {
-            let { group, requests } =
-                this._createGroupTree(baseTree, path, '', _url)
-            if (group) {
-                _group = _group.setIn(
+            let child = this._createGroupTree(baseTree, path, '', _url)
+            if (child) {
+                group = group.setIn(
                     [ 'children', path.relativeUri ],
-                    group
+                    child
                 )
-            }
-
-            if (requests) {
-                Object.assign(_requests, requests)
             }
         }
 
         (tree.methods || []).forEach(
             data => {
-                let request =
+                group = group.setIn(
+                    [ 'children', data.method ],
                     this._createRequest(baseTree, data, _url, data.method)
-
-                let uuid = this._uuid()
-                _requests[uuid] = request
-                _group = _group.setIn([ 'children', data.method ], uuid)
+                )
             }
         )
 
-        if (_group && _group.get('children').size > 0) {
-            return { group: _group, requests: _requests }
+        if (group && group.get('children').size > 0) {
+            return group
         }
 
-        return { group: null, requests: {} }
+        return null
     }
 
     _createRequest(raml, req, url, method) {
@@ -735,8 +721,7 @@ export default class RAMLParser {
 
             for (let scheme of raml.securitySchemes || []) {
                 if (Object.keys(scheme)[0] === securedName) {
-                    const authName = Object.keys(scheme)[0]
-                    let security = scheme[authName]
+                    let security = scheme[Object.keys(scheme)[0]]
 
                     let securityMap = {
                         'OAuth 2.0': this._extractOAuth2Auth,
@@ -747,9 +732,7 @@ export default class RAMLParser {
 
                     let rule = securityMap[security.type]
                     if (rule) {
-                        auths = auths.push(
-                          rule(raml, authName, security, params)
-                        )
+                        auths = auths.push(rule(raml, security, params))
                     }
                 }
             }
@@ -757,7 +740,7 @@ export default class RAMLParser {
         return auths
     }
 
-    _extractOAuth2Auth(raml, authName = null, security, params) {
+    _extractOAuth2Auth(raml, security, params) {
         let flowMap = {
             code: 'accessCode',
             token: 'implicit',
@@ -766,7 +749,6 @@ export default class RAMLParser {
         }
         let _params = params || {}
         let auth = new Auth.OAuth2({
-            authName,
             flow:
                 flowMap[(_params.authorizationGrants || [])[0]] ||
                 flowMap[security.settings.authorizationGrants[0]] ||
@@ -789,10 +771,9 @@ export default class RAMLParser {
         return auth
     }
 
-    _extractOAuth1Auth(raml, authName = null, security, params) {
+    _extractOAuth1Auth(raml, security, params) {
         let _params = params || {}
         let auth = new Auth.OAuth1({
-            authName,
             authorizationUri:
                 _params.authorizationUri ||
                 security.settings.authorizationUri ||
@@ -810,13 +791,13 @@ export default class RAMLParser {
         return auth
     }
 
-    _extractBasicAuth(raml, authName = null) {
-        let auth = new Auth.Basic({ authName })
+    _extractBasicAuth() {
+        let auth = new Auth.Basic()
         return auth
     }
 
-    _extractDigestAuth(raml, authName = null) {
-        let auth = new Auth.Digest({ authName })
+    _extractDigestAuth() {
+        let auth = new Auth.Digest()
         return auth
     }
 

--- a/src/parsers/swagger/v2.0/Parser.js
+++ b/src/parsers/swagger/v2.0/Parser.js
@@ -119,17 +119,15 @@ export default class SwaggerParser {
 
             let rootGroup = new Group()
             rootGroup = rootGroup.set('name', swaggerCollection.info.title)
-            let pathLinkedRequests = this._applyFuncOverPathArchitecture(
-                swaggerCollection,
-                ::this._createRequest
-            )
+            let requests = this._extractRequests(swaggerCollection)
 
-            rootGroup = this._createGroupTree(rootGroup, pathLinkedRequests)
+            rootGroup = this._createGroupTree(rootGroup, requests)
 
             let info = this._extractContextInfo(swaggerCollection.info)
 
             let reqContext = new Context()
             reqContext = reqContext
+                .set('requests', new Immutable.OrderedMap(requests))
                 .set('group', rootGroup)
                 .setIn([ 'references', 'schemas' ], refs)
                 .set('info', info)
@@ -392,9 +390,20 @@ export default class SwaggerParser {
         return params
     }
 
+    _uuid() {
+        let d = new Date().getTime()
+        let uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+            .replace(/[xy]/g, c => {
+                let r = (d + Math.random() * 16) % 16 | 0
+                d = Math.floor(d / 16)
+                return (c === 'x' ? r : r & 0x3 | 0x8).toString(16)
+            })
+        return uuid
+    }
+
     // @tested
-    _applyFuncOverPathArchitecture(collection, func) {
-        let architecture = {}
+    _extractRequests(collection) {
+        let requests = {}
 
         let filterOtherFieldsOutFunc = (bool) => {
             return (val) => {
@@ -410,56 +419,59 @@ export default class SwaggerParser {
             }
         }
 
-        for (let path in collection.paths) {
-            if (collection.paths.hasOwnProperty(path)) {
-                architecture[path] = architecture[path] || {}
-                let methods = collection.paths[path]
-                let _methods = Object.keys(methods)
-                if (methods.parameters) {
-                    let _params = this._getParameters(
-                        collection,
-                        methods.parameters
-                    )
-
-                    let paramKey = _methods.indexOf('parameters')
-                    // remove paramKey
-                    _methods.splice(paramKey, 1)
-
-                    for (let method of _methods) {
-                        let params = this._updateParametersInMethod(
-                            methods[method],
-                            _params
-                        )
-                        methods[method].parameters = params
-                    }
-                }
-
-                let validMethods = _methods.filter(
-                    filterOtherFieldsOutFunc(true)
+        let pathMap = collection.paths
+        const paths = Object.keys(pathMap)
+        for (let path of paths) {
+            let methodMap = pathMap[path]
+            let methods = Object.keys(methodMap)
+            if (methodMap.parameters) {
+                let _params = this._getParameters(
+                    collection,
+                    methodMap.parameters
                 )
 
-                let description = _methods.filter(
-                    filterOtherFieldsOutFunc(false)
-                ).reduce(createOtherFieldDescFunc(methods), '')
+                let paramKey = methods.indexOf('parameters')
+                // remove paramKey
+                methods.splice(paramKey, 1)
 
-                if (description) {
-                    description = 'The following fields were provided at the ' +
-                        'path level:' + description
-                }
-
-                for (let method of validMethods) {
-                    architecture[path][method] = func(
-                        collection,
-                        path,
-                        method,
-                        methods[method],
-                        description
+                for (let method of methods) {
+                    let params = this._updateParametersInMethod(
+                        methodMap[method],
+                        _params
                     )
+                    methodMap[method].parameters = params
                 }
+            }
+
+            let validMethods = methods.filter(
+                filterOtherFieldsOutFunc(true)
+            )
+
+            let description = methods.filter(
+                filterOtherFieldsOutFunc(false)
+            ).reduce(createOtherFieldDescFunc(methods), '')
+
+            if (description) {
+                description = 'The following fields were provided at the ' +
+                    'path level:' + description
+            }
+
+            for (let method of validMethods) {
+                let request = this._createRequest(
+                    collection,
+                    path,
+                    method,
+                    methodMap[method],
+                    description
+                )
+
+                let uuid = this._uuid()
+
+                requests[uuid] = request
             }
         }
 
-        return architecture
+        return requests
     }
 
     _getParameters(collection, params) {
@@ -909,11 +921,69 @@ export default class SwaggerParser {
         return new Immutable.List(bodies)
     }
 
-    // @tested
-    _createGroupTree(group, paths) {
+    _formatSequenceParam(_param) {
+        if (_param.get('format') !== 'sequence') {
+            let schema = _param.getJSONSchema(false, true)
+            if (!schema.enum && typeof schema.default !== 'undefined') {
+                schema.enum = [ schema.default ]
+            }
+            let generated = _param.generate(false, schema)
+            return generated
+        }
+
+        let schema = _param.getJSONSchema()
+
+        if (!schema['x-sequence']) {
+            return _param.generate()
+        }
+
+        for (let sub of schema['x-sequence']) {
+            if (sub['x-title']) {
+                sub.enum = [ '{' + sub['x-title'] + '}' ]
+            }
+        }
+
+        let generated = _param.generate(false, schema)
+        return generated
+    }
+
+
+    _createTagGroupTree(group, tagLists) {
         let _group = group
-        for (let path in paths) {
-            if (paths.hasOwnProperty(path)) {
+        if (!group || !(group instanceof Group)) {
+            _group = new Group({
+                name: 'root'
+            })
+        }
+        const tagGroups = tagLists.reduce((tagGroup, { tags, uuid }) => {
+            const firstTag = tags.get(0) || 'Uncategorized'
+            tagGroup[firstTag] = tagGroup[firstTag] || new Group({
+                name: firstTag
+            })
+
+            tagGroup[firstTag] = tagGroup[firstTag]
+                .setIn([ 'children', uuid ], uuid)
+            return tagGroup
+        }, {})
+
+        return _group.set('children', new Immutable.OrderedMap(tagGroups))
+    }
+
+    _createPathGroupTree(group, paths) {
+        let _group = group
+        if (!group || !(group instanceof Group)) {
+            _group = new Group({
+                name: 'root'
+            })
+        }
+        const pathMap = paths.reduce((_pathMap, { uuid, path, method }) => {
+            _pathMap[path] = _pathMap[path] || {}
+            _pathMap[path][method] = uuid
+            return _pathMap
+        }, {})
+
+        for (let path in pathMap) {
+            if (pathMap.hasOwnProperty(path)) {
                 let nodes = path.split('/')
 
                 if (path.indexOf('/') === 0) {
@@ -934,11 +1004,11 @@ export default class SwaggerParser {
                 }
 
                 keyPath.push('children')
-                for (let method in paths[path]) {
-                    if (paths[path].hasOwnProperty(method)) {
+                for (let method in pathMap[path]) {
+                    if (pathMap[path].hasOwnProperty(method)) {
                         _group = _group.setIn(
                             keyPath.concat(method),
-                            paths[path][method]
+                            pathMap[path][method]
                         )
                     }
                 }
@@ -946,6 +1016,38 @@ export default class SwaggerParser {
         }
 
         return _group
+    }
+
+    // @tested
+    _createGroupTree(group, requestMap) {
+        const uuids = Object.keys(requestMap)
+
+        const tagLists = uuids
+            .map(uuid => {
+                const tags = requestMap[uuid].get('tags')
+                return { uuid, tags }
+            })
+
+        const countRequestWithTags = tagLists
+            .filter(({ tags }) => tags.size > 0)
+            .length
+
+        if (countRequestWithTags < uuids.length * 0.5) {
+            const paths = uuids.map(uuid => {
+                const path = this._formatSequenceParam(
+                    requestMap[uuid].getIn([ 'url', 'pathname' ])
+                )
+
+                const method = requestMap[uuid].get('method')
+
+                return { uuid, path, method }
+            })
+
+            return this._createPathGroupTree(group, paths)
+        }
+        else {
+            return this._createTagGroupTree(group, tagLists)
+        }
     }
 
     _extractSequenceParam(_sequence, _key, parameters) {

--- a/src/parsers/swagger/v2.0/Parser.js
+++ b/src/parsers/swagger/v2.0/Parser.js
@@ -313,18 +313,21 @@ export default class SwaggerParser {
     _setBasicAuth(authName = null, definition) {
         let username = null
         let password = null
+        let description = null
 
         if (definition) {
-            username = definition['x-username'] || null
-            password = definition['x-password'] || null
+            username = definition.get('x-username') || null
+            password = definition.get('x-password') || null
+            description = definition.get('description') || null
         }
 
-        return new Auth.Basic({ authName, username, password })
+        return new Auth.Basic({ authName, username, password, description })
     }
 
     _setApiKeyAuth(authName = null, definition) {
         return new Auth.ApiKey({
             authName,
+            description: definition.get('description') || null,
             in: definition.get('in'),
             name: definition.get('name')
         })
@@ -333,6 +336,7 @@ export default class SwaggerParser {
     _setOAuth2Auth(authName = null, definition) {
         return new Auth.OAuth2({
             authName,
+            description: definition.get('description') || null,
             flow: definition.get('flow', null),
             authorizationUrl: definition.get('authorizationUrl', null),
             tokenUrl: definition.get('tokenUrl', null),

--- a/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
+++ b/src/parsers/swagger/v2.0/__tests__/fixtures/Parser-fixtures.js
@@ -1262,7 +1262,10 @@ export default class SwaggerFixtures {
                 ],
                 output: new Request({
                     auths: new Immutable.List([
-                        new Auth.Basic({ authName: 'basicAuth' })
+                        new Auth.Basic({
+                            authName: 'basicAuth',
+                            description: 'HTTP Basic Authentication'
+                        })
                     ])
                 })
             },
@@ -1368,7 +1371,10 @@ export default class SwaggerFixtures {
                 ],
                 output: new Request({
                     auths: new Immutable.List([
-                        new Auth.Basic({ authName: 'basicAuth' }),
+                        new Auth.Basic({
+                            authName: 'basicAuth',
+                            description: 'HTTP Basic Authentication'
+                        }),
                         new Auth.ApiKey({
                             authName: 'api_key',
                             name: 'api_key',

--- a/src/resolvers/__tests__/ParameterResolver-test.js
+++ b/src/resolvers/__tests__/ParameterResolver-test.js
@@ -1367,21 +1367,14 @@ export class TestParameterResolver extends UnitTest {
 
         resolver._updateAuths(auths, null)
 
-        this.assertEqual(resolver.spy._getValueFromKey.count, 9)
+        this.assertEqual(resolver.spy._getValueFromKey.count, 11)
     }
 
     @targets('_updateAuths')
     testUpdateAuthsReturnsExpectedAuthList() {
         const resolver = this.__init()
 
-        let returnNull = false
         resolver.spyOn('_getValueFromKey', () => {
-            if (returnNull) {
-                returnNull = false
-                return null
-            }
-
-            returnNull = true
             return new ParameterItem({
                 value: 12
             })
@@ -1395,11 +1388,17 @@ export class TestParameterResolver extends UnitTest {
         const expected = new Immutable.List([
             new Auth.Basic({
                 _model: 12,
+                description: 12,
+                authName: 12,
                 username: 12,
+                password: 12,
                 raw: 12
             }),
             new Auth.Digest({
+                _model: 12,
+                description: 12,
                 authName: 12,
+                username: 12,
                 password: 12
             })
         ])

--- a/src/serializers/cURL/Serializer.js
+++ b/src/serializers/cURL/Serializer.js
@@ -21,7 +21,7 @@ export default class CurlSerializer extends BaseSerializer {
 
     _formatContent(context) {
         let [ startInfo, endInfo ] = this._formatInfo(context)
-        let group = this._formatGroup(context.get('group'))
+        let group = this._formatGroup(context.get('requests').valueSeq())
         let references = this._formatReferences(context.get('references'))
 
         let formatted = [
@@ -109,12 +109,10 @@ export default class CurlSerializer extends BaseSerializer {
         return formatted.join('\n')
     }
 
-    _formatGroup(group) {
-        if (!group) {
+    _formatGroup(requests) {
+        if (!requests || !requests.size) {
             return ''
         }
-
-        let requests = group.getRequests()
 
         let formatted = []
         requests.forEach(request => {

--- a/src/serializers/paw/Serializer.js
+++ b/src/serializers/paw/Serializer.js
@@ -2,8 +2,6 @@ import Context, {
     Parameter
 } from '../../models/Core'
 
-import Request from '../../models/Request'
-
 import LateResolutionReference from '../../models/references/LateResolution'
 import JSONSchemaReference from '../../models/references/JSONSchema'
 import Reference from '../../models/references/Reference'
@@ -251,7 +249,7 @@ export default class PawSerializer {
     }
 
     _importPawRequests(requestContext, item, options) {
-        const requests = requestContext.getRequests()
+        const requests = requestContext.get('requests')
         const group = requestContext.get('group')
         const references = requestContext.get('references')
 
@@ -303,7 +301,9 @@ export default class PawSerializer {
             return pawGroup
         }
 
+
         this._applyFuncOverGroupTree(
+            requests,
             group,
             (request, requestParent) => {
                 ::this._importPawRequest(
@@ -576,16 +576,20 @@ export default class PawSerializer {
         return pawRequest
     }
 
-    _applyFuncOverGroupTree(group, leafFunc, nodeFunc, pawGroup) {
+    _applyFuncOverGroupTree(requests, group, leafFunc, nodeFunc, pawGroup) {
         let calls = []
         let currentPawGroup = nodeFunc(group.get('name') || '', pawGroup)
         group.get('children').forEach((child) => {
-            if (child instanceof Request) {
-                calls.push(leafFunc(child, currentPawGroup))
+            if (typeof child === 'string' || typeof child === 'number') {
+                const request = requests.get(child)
+                if (request) {
+                    calls.push(leafFunc(request, currentPawGroup))
+                }
             }
             else {
                 calls = calls.concat(
                     this._applyFuncOverGroupTree(
+                        requests,
                         child,
                         leafFunc,
                         nodeFunc,

--- a/src/serializers/paw/__tests__/fixtures/Serializer-fixtures.js
+++ b/src/serializers/paw/__tests__/fixtures/Serializer-fixtures.js
@@ -8,6 +8,7 @@ export default class BaseImporterFixtures {
             {
                 name: 'SimpleTest',
                 inputs: [
+                    new Immutable.OrderedMap(),
                     new Group(),
                     null,
                     (currentName, parent) => {
@@ -19,14 +20,18 @@ export default class BaseImporterFixtures {
             {
                 name: 'SingleDepthGroupTest',
                 inputs: [
+                    new Immutable.OrderedMap({
+                        1: new Request({
+                            name: 1
+                        }),
+                        2: new Request({
+                            name: 2
+                        })
+                    }),
                     new Group({
                         children: new Immutable.OrderedMap({
-                            '/test': new Request({
-                                name: 1
-                            }),
-                            '/path': new Request({
-                                name: 2
-                            })
+                            '/test': '1',
+                            '/path': '2'
                         })
                     }),
                     (arg) => {
@@ -41,16 +46,20 @@ export default class BaseImporterFixtures {
             {
                 name: 'MultipleDepthGroupTest',
                 inputs: [
+                    new Immutable.OrderedMap({
+                        1: new Request({
+                            name: 1
+                        }),
+                        2: new Request({
+                            name: 2
+                        })
+                    }),
                     new Group({
                         children: new Immutable.OrderedMap({
-                            '/test': new Request({
-                                name: 1
-                            }),
+                            '/test': '1',
                             subTree: new Group({
                                 children: new Immutable.OrderedMap({
-                                    '/path': new Request({
-                                        name: 2
-                                    })
+                                    '/path': '2'
                                 })
                             })
                         })

--- a/src/serializers/postman/Serializer.js
+++ b/src/serializers/postman/Serializer.js
@@ -107,7 +107,7 @@ export default class PostmanSerializer extends BaseSerializer {
 
     _formatRequests(context, collectionId) {
         let reqs = []
-        let requests = context.getRequests()
+        let requests = context.get('requests').valueSeq()
 
         requests.forEach(request => {
             let formatted = this._formatRequest(request, collectionId)

--- a/src/serializers/raml/Serializer.js
+++ b/src/serializers/raml/Serializer.js
@@ -41,14 +41,13 @@ export default class RAMLSerializer extends BaseSerializer {
         let structure = {}
         let basicInfo = this._formatBasicInfo(context)
 
-        let group = context.get('group')
+        const requests = context.get('requests').valueSeq()
         let urlInfo = {}
         let securitySchemes = {}
         let paths = {}
         let schemas = this._formatSchemas(context.get('references'))
 
-        if (group) {
-            let requests = group.getRequests()
+        if (requests.size) {
             urlInfo = ::this._formatURLInfo(requests)
             securitySchemes = ::this._formatSecuritySchemes(requests)
             paths = ::this._formatPaths(requests)

--- a/src/serializers/raml/Serializer.js
+++ b/src/serializers/raml/Serializer.js
@@ -450,11 +450,16 @@ export default class RAMLSerializer extends BaseSerializer {
             authorizationGrants: [ authorizationGrants ]
         }
 
+        if (auth.get('description')) {
+            formatted.description = auth.get('description')
+        }
+
         formatted.settings = settings
 
-        let result = {
-            oauth_2_0: formatted
-        }
+        let name = auth.get('authName') || 'oauth_2_0'
+
+        let result = {}
+        result[name] = formatted
 
         return result
     }
@@ -477,27 +482,50 @@ export default class RAMLSerializer extends BaseSerializer {
             formatted.settings = settings
         }
 
-        let result = {
-            oauth_1_0: formatted
+        if (auth.get('description')) {
+            formatted.description = auth.get('description')
         }
+
+        let name = auth.get('name') || 'oauth_1_0'
+
+        let result = {}
+        result[name] = formatted
 
         return result
     }
 
-    _formatDigest() {
-        return {
-            digest: {
-                type: 'Digest Authentication'
-            }
+    _formatDigest(auth) {
+        let formatted = {
+            type: 'Digest Authentication'
         }
+
+        if (auth.get('description')) {
+            formatted.description = auth.get('description')
+        }
+
+        let name = auth.get('name') || 'digest'
+
+        let result = {}
+        result[name] = formatted
+
+        return result
     }
 
-    _formatBasic() {
-        return {
-            basic: {
-                type: 'Basic Authentication'
-            }
+    _formatBasic(auth) {
+        let formatted = {
+            type: 'Basic Authentication'
         }
+
+        if (auth.get('description')) {
+            formatted.description = auth.get('description')
+        }
+
+        let name = auth.get('name') || 'basic'
+
+        let result = {}
+        result[name] = formatted
+
+        return result
     }
 
     _formatPaths(requests) {

--- a/src/serializers/raml/__tests__/Serializer-test.js
+++ b/src/serializers/raml/__tests__/Serializer-test.js
@@ -13,7 +13,6 @@ import {
     Info, Contact, License
 } from '../../../models/Utils'
 
-import Group from '../../../models/Group'
 import Auth from '../../../models/Auth'
 import Constraint from '../../../models/Constraint'
 import URL from '../../../models/URL'
@@ -108,7 +107,7 @@ export class TestRAMLSerializer extends UnitTest {
         })
 
         let input = new Context({
-            group: new Group()
+            requests: new Immutable.OrderedMap({ a: 12 })
         })
 
         let expected = {

--- a/src/serializers/raml/__tests__/Serializer-test.js
+++ b/src/serializers/raml/__tests__/Serializer-test.js
@@ -892,13 +892,18 @@ export class TestRAMLSerializer extends UnitTest {
     testFormatDigest() {
         let s = this.__init()
 
+        const input = new Auth.Digest({
+            description: 'some desc'
+        })
+
         let expected = {
             digest: {
+                description: 'some desc',
                 type: 'Digest Authentication'
             }
         }
 
-        let result = s._formatDigest()
+        let result = s._formatDigest(input)
 
         this.assertEqual(expected, result)
     }
@@ -907,13 +912,18 @@ export class TestRAMLSerializer extends UnitTest {
     testFormatBasic() {
         let s = this.__init()
 
+        const input = new Auth.Digest({
+            description: 'some desc'
+        })
+
         let expected = {
             basic: {
+                description: 'some desc',
                 type: 'Basic Authentication'
             }
         }
 
-        let result = s._formatBasic()
+        let result = s._formatBasic(input)
 
         this.assertEqual(expected, result)
     }

--- a/src/serializers/swagger/Serializer.js
+++ b/src/serializers/swagger/Serializer.js
@@ -21,7 +21,7 @@ export default class SwaggerSerializer extends BaseSerializer {
 
         let info = this._formatInfo(context)
 
-        let requests = context.getRequests()
+        let requests = context.get('requests').valueSeq()
         let [ host, schemes ] = this._formatHost(requests)
         this.host = host
         let [ paths, securityDefs ] = this._formatPaths(

--- a/src/serializers/swagger/Serializer.js
+++ b/src/serializers/swagger/Serializer.js
@@ -750,31 +750,56 @@ export default class SwaggerSerializer extends BaseSerializer {
     }
 
     _formatBasicAuth(context, auth) {
-        let definition = {
-            basic_auth: {
-                type: 'basic',
-                'x-username': auth.get('username'),
-                'x-password': auth.get('password')
-            }
+        const name = auth.get('authName') || 'basic_auth'
+        const securityDefinition = {
+            type: 'basic'
         }
 
-        return [ definition, { basic_auth: [] } ]
+        if (auth.get('username')) {
+            securityDefinition['x-username'] = auth.get('username')
+        }
+
+        if (auth.get('password')) {
+            securityDefinition['x-password'] = auth.get('password')
+        }
+
+        if (auth.get('description')) {
+            securityDefinition.description = auth.get('description')
+        }
+
+        const definition = {}
+        definition[name] = securityDefinition
+
+        const secured = {}
+        secured[name] = []
+
+        return [ definition, secured ]
     }
 
     _formatApiKeyAuth(context, auth) {
-        let definition = {
-            api_key_auth: {
-                type: 'apiKey',
-                name: auth.get('name'),
-                in: auth.get('in')
-            }
+        const name = auth.get('authName') || 'api_key_auth'
+        const securityDefinition = {
+            type: 'apiKey',
+            name: auth.get('name'),
+            in: auth.get('in')
         }
 
-        return [ definition, { api_key_auth: [] } ]
+        if (auth.get('description')) {
+            securityDefinition.description = auth.get('description')
+        }
+
+        const definition = {}
+        definition[name] = securityDefinition
+
+        const secured = {}
+        secured[name] = []
+
+        return [ definition, secured ]
     }
 
     _formatOAuth2Auth(context, auth) {
         let scopes = auth.get('scopes')
+        const name = auth.get('authName') || 'oauth_2_auth'
 
         let _definition = {
             type: 'oauth2'
@@ -792,26 +817,28 @@ export default class SwaggerSerializer extends BaseSerializer {
             _definition.flow = auth.get('flow')
         }
 
-        let definition = {
-            oauth_2_auth: _definition
+        if (auth.get('description')) {
+            _definition.description = auth.get('description')
         }
+
+        const definition = {}
+        definition[name] = _definition
 
         let scopeDescriptions = {}
         let security
         if (scopes) {
             scopes = Array.isArray(scopes) ? scopes : scopes.toJS()
-            security = {
-                oauth_2_auth: scopes
-            }
+            security = {}
+            security[name] = scopes
 
             scopes.forEach(scope => {
                 scopeDescriptions[scope] = ''
             })
 
-            definition.oauth_2_auth.scopes = scopeDescriptions
+            definition[name].scopes = scopeDescriptions
         }
         else {
-            security = 'oauth_2_auth'
+            security = name
         }
 
         return [ definition, security ]

--- a/src/serializers/swagger/Serializer.js
+++ b/src/serializers/swagger/Serializer.js
@@ -843,6 +843,7 @@ export default class SwaggerSerializer extends BaseSerializer {
                             subTree[fragment]
                         subTree = subTree[fragment]
                     }
+
                     let ref = container.resolve(key).get('value')
 
                     if (typeof ref === 'undefined' || ref === null) {


### PR DESCRIPTION
## Ready for review

### Changes:
#### Model
- Adds a field `requests` to the `Context` object. the `requests` field is an `Immutable.OrderedMap<uuid,Request>` object
- Removes `Request` objects from groups. `uuids` are used instead that link the children to the locations in the groups.

#### Parsers
- All parsers have been updated to match the new model

#### Serializers
- All serializers have been updated to match the new model