### PR TITLE
improved paw parser management of environment variables

### DIFF
--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -465,10 +465,16 @@ export default class PawParser {
             }
         }
 
+        let value = null
+        if (typeof schema.default !== 'undefined') {
+            value = schema.default
+        }
+
         let param = new Parameter({
             key: _key,
             name: name,
             type: type,
+            value: value,
             internals: new Immutable.List(internals),
             externals: externals
         })

--- a/src/parsers/paw/dv/DVManager.js
+++ b/src/parsers/paw/dv/DVManager.js
@@ -38,7 +38,7 @@ export default class DynamicValueManager {
         }
 
         if (identifierMap[identifier]) {
-            return identifierMap[identifier](dv, this.ctx)
+            return identifierMap[identifier].convert(dv, this.ctx)
         }
 
         return dv.getEvaluatedString()

--- a/src/parsers/paw/dv/DynamicValueConverter.js
+++ b/src/parsers/paw/dv/DynamicValueConverter.js
@@ -1,10 +1,6 @@
 export default class DynamicValueConverter {
     static identifier = null
 
-    constructor(dv, ctx) {
-        this.dv = this.convert(dv, ctx)
-    }
-
     convert() {
         throw new Error(
             'DynamicValue is an abstract class. This method must be ' +

--- a/src/parsers/paw/dv/EnvironmentVariable.js
+++ b/src/parsers/paw/dv/EnvironmentVariable.js
@@ -4,48 +4,71 @@ import JSONSchemaReference from '../../../models/references/JSONSchema'
 
 export default class EnvironmentVariable extends DynamicValueConverter {
     convert(dv, ctx) {
-        let id = dv.environmentVariable
-        let variable = ctx.getEnvironmentVariableById(id)
+        const variable = this._getVariableFromContext(dv, ctx)
 
         if (typeof variable === 'undefined' || variable === null) {
             return null
         }
 
-        let name = variable.name
-        let value = null
-        let currentValue = variable.getCurrentValue(true)
+        const uri = this._getUri(variable)
+        const schema = this._getSchema(variable)
+        const reference = this._createJSONSchemaReference(uri, schema)
 
-        if (currentValue && currentValue.length === 1) {
-            let component = currentValue.getComponentAtIndex(0)
+        return reference
+    }
 
-            let jsfId =
+    _getVariableFromContext(dv, ctx) {
+        const id = dv.environmentVariable
+        const variable = ctx.getEnvironmentVariableById(id)
+        return variable
+    }
+
+    _getSchema(variable) {
+        const jsfId =
                 'com.luckymarmot.PawExtensions' +
                 '.JSONSchemaFakerDynamicValue'
-            if (component.type === jsfId) {
-                return this._jsfConvert(name, component)
+
+        const currentValue = variable.getCurrentValue(true)
+
+        let value = null
+        if (
+            currentValue &&
+            currentValue.length === 1 &&
+            currentValue.getComponentAtIndex(0).type === jsfId
+        ) {
+            value = JSON.parse(currentValue.getComponentAtIndex(0).schema)
+        }
+        else if (
+            currentValue &&
+            typeof currentValue.getEvaluatedString === 'function'
+        ) {
+            value = {
+                type: 'string',
+                default: currentValue.getEvaluatedString()
             }
         }
 
-        if (
-            !currentValue ||
-            typeof currentValue.getEvaluatedString !== 'function'
-        ) {
-            value = null
-        }
-        else {
-            value = currentValue.getEvaluatedString()
-        }
+        return value
+    }
 
-        let uri = this._convertNameToFragment(name)
-        return new JSONSchemaReference({
+    _getUri(variable) {
+        const name = variable.name
+        const uri = this._convertNameToFragment(name)
+
+        return uri
+    }
+
+    _createJSONSchemaReference(uri, schema) {
+        let ref = new JSONSchemaReference({
             uri: uri,
             relative: uri,
-            value: {
-                type: 'string',
-                default: value
-            },
+            value: schema,
             resolved: true
         })
+
+        let dependencies = ref._findRefs(schema)
+
+        return ref.set('dependencies', dependencies)
     }
 
     _convertNameToFragment(name) {
@@ -58,20 +81,5 @@ export default class EnvironmentVariable extends DynamicValueConverter {
 
     _escapeURIFragment(uriFragment) {
         return uriFragment.replace(/~/g, '~0').replace(/\//g, '~1')
-    }
-
-    _jsfConvert(name, component) {
-        let uri = this._convertNameToFragment(name)
-        let schema = JSON.parse(component.schema)
-        let ref = new JSONSchemaReference({
-            uri: uri,
-            relative: uri,
-            value: schema,
-            resolved: true
-        })
-
-        let dependencies = ref._findRefs(component.schema)
-
-        return ref.set('dependencies', dependencies)
     }
 }

--- a/src/parsers/paw/dv/EnvironmentVariable.js
+++ b/src/parsers/paw/dv/EnvironmentVariable.js
@@ -1,7 +1,6 @@
 import DynamicValueConverter from './DynamicValueConverter'
 
 import JSONSchemaReference from '../../../models/references/JSONSchema'
-import ExoticReference from '../../../models/references/Exotic'
 
 export default class EnvironmentVariable extends DynamicValueConverter {
     convert(dv, ctx) {
@@ -38,10 +37,13 @@ export default class EnvironmentVariable extends DynamicValueConverter {
         }
 
         let uri = this._convertNameToFragment(name)
-        return new ExoticReference({
+        return new JSONSchemaReference({
             uri: uri,
             relative: uri,
-            value: value,
+            value: {
+                type: 'string',
+                default: value
+            },
             resolved: true
         })
     }

--- a/src/parsers/paw/dv/__tests__/EnvironmentVariable-test.js
+++ b/src/parsers/paw/dv/__tests__/EnvironmentVariable-test.js
@@ -1,0 +1,324 @@
+import {
+    UnitTest,
+    registerTest,
+    targets,
+    against
+} from '../../../../utils/TestUtils'
+
+import EnvironmentVariable from '../EnvironmentVariable'
+import JSONSchemaReference from '../../../../models/references/JSONSchema'
+
+import {
+    Mock,
+    ClassMock,
+    PawContextMock,
+    DynamicString,
+    DynamicValue
+} from '../../../../mocks/PawMocks'
+
+@registerTest
+@against(EnvironmentVariable)
+export class TestEnvironmentVariable extends UnitTest {
+
+    @targets('convert')
+    testConvertCallsGetVariableFromContext() {
+        const { ev, ctx } = this.__init()
+
+        const dv = new DynamicValue(
+            'com.luckymarmot.EnvironmentVariable',
+            12
+        )
+
+        ev.spyOn('_getVariableFromContext', () => null)
+
+        const expected = null
+        const result = ev.convert(dv, ctx)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(ev.spy._getVariableFromContext.count, 1)
+    }
+
+    @targets('convert')
+    testConvertCallsGetURI() {
+        const { ev, ctx } = this.__init()
+
+        const dv = new DynamicValue(
+            'com.luckymarmot.EnvironmentVariable',
+            12
+        )
+
+        ev.spyOn('_getVariableFromContext', () => 12)
+        ev.spyOn('_getUri', () => 42)
+        ev.spyOn('_getSchema', () => 90)
+        ev.spyOn('_createJSONSchemaReference', () => 33)
+
+        const expected = 33
+        const result = ev.convert(dv, ctx)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(ev.spy._getUri.count, 1)
+        this.assertEqual(
+            ev.spy._getUri.calls[0],
+            [ 12 ]
+        )
+    }
+
+    @targets('convert')
+    testConvertCallsGetSchema() {
+        const { ev, ctx } = this.__init()
+
+        const dv = new DynamicValue(
+            'com.luckymarmot.EnvironmentVariable',
+            12
+        )
+
+        ev.spyOn('_getVariableFromContext', () => 12)
+        ev.spyOn('_getUri', () => 42)
+        ev.spyOn('_getSchema', () => 90)
+        ev.spyOn('_createJSONSchemaReference', () => 33)
+
+        const expected = 33
+        const result = ev.convert(dv, ctx)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(ev.spy._getSchema.count, 1)
+        this.assertEqual(
+            ev.spy._getSchema.calls[0],
+            [ 12 ]
+        )
+    }
+
+    @targets('convert')
+    testConvertCallsGetURI() {
+        const { ev, ctx } = this.__init()
+
+        const dv = new DynamicValue(
+            'com.luckymarmot.EnvironmentVariable',
+            12
+        )
+
+        ev.spyOn('_getVariableFromContext', () => 12)
+        ev.spyOn('_getUri', () => 42)
+        ev.spyOn('_getSchema', () => 90)
+        ev.spyOn('_createJSONSchemaReference', () => 33)
+
+        const expected = 33
+        const result = ev.convert(dv, ctx)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(ev.spy._createJSONSchemaReference.count, 1)
+        this.assertEqual(
+            ev.spy._createJSONSchemaReference.calls[0],
+            [ 42, 90 ]
+        )
+    }
+
+    @targets('_getVariableFromContext')
+    testGetVariableFromContextCallsContextGetEnvironmentVariableById() {
+        const { ev, ctx } = this.__init()
+
+        ctx.$$_spyOn('getEnvironmentVariableById', () => 1242)
+
+        const dv = new DynamicValue(
+            'com.luckymarmot.EnvironmentVariable',
+            {
+                environmentVariable: 1234
+            }
+        )
+
+        const expected = 1242
+        const result = ev._getVariableFromContext(dv, ctx)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(ctx.$$_spy.getEnvironmentVariableById.count, 1)
+        this.assertEqual(
+            ctx.$$_spy.getEnvironmentVariableById.calls[0],
+            [ 1234 ]
+        )
+    }
+
+    @targets('_getSchema')
+    testGetSchemaCallsVariableGetCurrentValue() {
+        const { ev } = this.__init()
+
+        const variable = new Mock({
+            getCurrentValue: () => null
+        })
+
+        const expected = null
+        const result = ev._getSchema(variable)
+
+        this.assertEqual(expected, result)
+        this.assertEqual(variable.$$_spy.getCurrentValue.count, 1)
+    }
+
+    @targets('_getSchema')
+    testGetSchemaWithJSFDynamicString() {
+        const { ev } = this.__init()
+
+        const schema = {
+            type: 'number',
+            minimum: 12,
+            maximum: 42
+        }
+
+        const ds = new DynamicString()
+        ds.length = 1
+        ds.$$_spyOn('getComponentAtIndex', () => {
+            return {
+                type: 'com.luckymarmot.PawExtensions' +
+                    '.JSONSchemaFakerDynamicValue',
+                schema: JSON.stringify(schema)
+            }
+        })
+
+        const variable = new Mock({
+            getCurrentValue: () => ds
+        })
+
+        const expected = schema
+        const result = ev._getSchema(variable)
+
+        this.assertEqual(expected, result)
+    }
+
+    @targets('_getSchema')
+    testGetSchemaWithOtherDynamicString() {
+        const { ev } = this.__init()
+
+        const schema = {
+            type: 'string',
+            default: '1242'
+        }
+
+        const ds = new DynamicString()
+        ds.length = 1
+        ds.$$_spyOn('getComponentAtIndex', () => {
+            return {
+                type: 'com.luckymarmot.PawExtensions' +
+                    '.someOtherExtension'
+            }
+        })
+
+        ds.$$_spyOn('getEvaluatedString', () => {
+            return '1242'
+        })
+
+        const variable = new Mock({
+            getCurrentValue: () => ds
+        })
+
+        const expected = schema
+        const result = ev._getSchema(variable)
+
+        this.assertEqual(expected, result)
+    }
+
+    @targets('_getSchema')
+    testGetSchemaWitNotADynamicString() {
+        const { ev } = this.__init()
+
+        const variable = new Mock({
+            getCurrentValue: () => {
+                return {
+                    length: 2
+                }
+            }
+        })
+
+        const expected = null
+        const result = ev._getSchema(variable)
+
+        this.assertEqual(expected, result)
+    }
+
+    @targets('_getUri')
+    testGetURICallsConvertNameToFragment() {
+        const { ev } = this.__init()
+
+        const expectedName = 'testName'
+        const uri = 'http://localhost/test'
+
+        const variable = {
+            name: expectedName
+        }
+
+        ev.spyOn('_convertNameToFragment', (name) => {
+            this.assertEqual(name, expectedName)
+            return uri
+        })
+
+        const expected = uri
+        const result = ev._getUri(variable)
+
+        this.assertEqual(ev.spy._convertNameToFragment.count, 1)
+        this.assertEqual(result, expected)
+    }
+
+    @targets('_convertNameToFragment')
+    testConvertNameToFragmentWithNameStartingWithHash() {
+        const { ev } = this.__init()
+        const name = '#test'
+
+        const expected = name
+        const result = ev._convertNameToFragment(name)
+
+        this.assertEqual(result, expected)
+    }
+
+    @targets('_convertNameToFragment')
+    testConvertNameToFragmentCallsEscapeURIFragmentWithNonHashName() {
+        const { ev } = this.__init()
+        const name = 'test'
+        const returnedFragment = 'test'
+
+        ev.spyOn('_escapeURIFragment', () => returnedFragment)
+
+        const expected = '#/definitions/' + returnedFragment
+        const result = ev._convertNameToFragment(name)
+
+        this.assertEqual(result, expected)
+    }
+
+    @targets('_escapeURIFragment')
+    testEscapeURIFragment() {
+        const { ev } = this.__init()
+
+        const fragment = '/some/complex~fragment~'
+
+        const expected = '~1some~1complex~0fragment~0'
+
+        const result = ev._escapeURIFragment(fragment)
+
+        this.assertEqual(expected, result)
+    }
+
+    @targets('_createJSONSchemaReference')
+    testCreateJSONSchemaReference() {
+        const { ev } = this.__init()
+
+        const uri = '#/definitions/User'
+        const schema = {
+            type: 'string',
+            pattern: '^.{4-16}$'
+        }
+
+        const expected = new JSONSchemaReference({
+            uri,
+            relative: uri,
+            value: schema,
+            resolved: true
+        })
+
+        const result = ev._createJSONSchemaReference(uri, schema)
+
+        this.assertEqual(result, expected)
+    }
+
+
+    __init() {
+        const ev = new ClassMock(new EnvironmentVariable(), '')
+        const ctx = new PawContextMock()
+        return { ev, ctx }
+    }
+}

--- a/src/serializers/paw/Serializer.js
+++ b/src/serializers/paw/Serializer.js
@@ -74,6 +74,84 @@ export default class PawSerializer {
         this.context = context || null
     }
 
+    _parserErrorHandler(e) {
+        /* eslint-disable no-console */
+        console.error(
+            '@parser failed with error',
+            e,
+            JSON.stringify(e),
+            e.stack
+        )
+        /* eslint-enable no-console */
+        throw e
+    }
+
+    _parserFailureHandler(e) {
+        /* eslint-disable no-console */
+        console.error(
+            '@parser caught error',
+            e,
+            JSON.stringify(e),
+            e.stack
+        )
+        /* eslint-enable no-console */
+        throw e
+    }
+
+    _serializerFailureHandler(e) {
+        /* eslint-disable no-console */
+        console.error(
+            '@serializer failed with error',
+            e,
+            JSON.stringify(e),
+            e.stack
+        )
+        throw e
+        /* eslint-enable no-console */
+    }
+
+    _resolverErrorHandler(error) {
+        /* eslint-disable no-console */
+        console.error(
+            '@resolver failed with error',
+            error,
+            JSON.stringify(error),
+            error.stack
+        )
+        throw error
+        /* eslint-enable no-console */
+    }
+
+    _resolverFailureHandler(error) {
+        /* eslint-disable no-console */
+        console.error(
+            '@resolver caught error',
+            error,
+            JSON.stringify(error),
+            error.stack
+        )
+        throw error
+        /* eslint-enable no-console */
+    }
+
+    _unsupportedAuthHandler(auth) {
+        /* eslint-disable no-console */
+        console.error(
+            'Auth type ' +
+            auth.constructor.name +
+            ' is not supported in Paw'
+        )
+        /* eslint-enable no-console */
+    }
+
+    _invalidJSONHandler() {
+        /* eslint-disable no-console */
+        console.error(
+            'body was set to JSON, but we couldn\'t parse it'
+        )
+        /* eslint-enable no-console */
+    }
+
     /*
       @params:
         - context
@@ -154,27 +232,7 @@ export default class PawSerializer {
             }, () => {
                 return false
             })
-        }, (e) => {
-            /* eslint-disable no-console */
-            console.error(
-                '@parser failed with error',
-                e,
-                JSON.stringify(e),
-                e.stack
-            )
-            /* eslint-enable no-console */
-            throw e
-        }).catch((e) => {
-            /* eslint-disable no-console */
-            console.error(
-                '@parser caught error',
-                e,
-                JSON.stringify(e),
-                e.stack
-            )
-            /* eslint-enable no-console */
-            throw e
-        })
+        }, ::this._parserErrorHandler).catch(::this._parserFailureHandler)
 
         return importPromise
     }
@@ -211,37 +269,9 @@ export default class PawSerializer {
                 return true
             }
             catch (e) {
-                /* eslint-disable no-console */
-                console.error(
-                    '@serializer failed with error',
-                    e,
-                    JSON.stringify(e),
-                    e.stack
-                )
-                throw e
-                /* eslint-enable no-console */
+                this._serializerFailureHandler(e)
             }
-        }, error => {
-            /* eslint-disable no-console */
-            console.error(
-                '@resolver failed with error',
-                error,
-                JSON.stringify(error),
-                error.stack
-            )
-            throw error
-            /* eslint-enable no-console */
-        }).catch(error => {
-            /* eslint-disable no-console */
-            console.error(
-                '@serializer caught error',
-                error,
-                JSON.stringify(error),
-                error.stack
-            )
-            throw error
-            /* eslint-enable no-console */
-        })
+        }, this._resolverErrorHandler).catch(this._resolverFailureHandler)
     }
 
     serialize(requestContext, opts = null, item, options) {
@@ -869,13 +899,7 @@ export default class PawSerializer {
                 }
             }
             else {
-                /* eslint-disable no-console */
-                console.error(
-                    'Auth type ' +
-                    auth.constructor.name +
-                    ' is not supported in Paw'
-                )
-                /* eslint-enable no-console */
+                this._unsupportedAuthHandler(auth)
             }
         }
         return pawReq
@@ -1001,11 +1025,7 @@ export default class PawSerializer {
                 pawReq.jsonBody = JSON.parse(component)
             }
             catch (e) {
-                /* eslint-disable no-console */
-                console.error(
-                    'body was set to JSON, but we couldn\'t parse it'
-                )
-                /* eslint-enable no-console */
+                this._invalidJSONHandler()
                 pawReq.body = content
             }
         }

--- a/src/serializers/paw/__tests__/Serializer-test.js
+++ b/src/serializers/paw/__tests__/Serializer-test.js
@@ -1118,6 +1118,9 @@ export class TestPawSerializer extends UnitTest {
 
         const importer = new BaseImporter()
         const mockedImporter = new ClassMock(importer, '')
+
+        mockedImporter.spyOn('_unsupportedAuthHandler', () => {})
+
         const requestMock = new PawRequestMock(null, '')
         const auths = new Immutable.List([
             new UnknownAuth()
@@ -1900,6 +1903,14 @@ export class TestPawSerializer extends UnitTest {
         const contextMock = new PawContextMock()
         const reqContext = new Context()
 
+        importer.spyOn('_parserErrorHandler', (e) => {
+            throw e
+        })
+
+        importer.spyOn('_parserFailureHandler', (e) => {
+            throw e
+        })
+
         importer.spyOn('createRequestContexts', () => {
             return [
                 {
@@ -1932,11 +1943,18 @@ export class TestPawSerializer extends UnitTest {
     }
 
     @targets('import')
-    testImportWithRejectedContext(done) {
+    testImportWithRejectedContextCallsParserErrorHandler(done) {
         const importer = new ClassMock(new BaseImporter(), '')
         const contextMock = new PawContextMock()
-
         let dummyError = new Error('dummy error')
+
+        importer.spyOn('_parserErrorHandler', (e) => {
+            throw e
+        })
+
+        importer.spyOn('_parserFailureHandler', (e) => {
+            throw e
+        })
 
         importer.spyOn('createRequestContexts', () => {
             return new Promise((_, reject) => {
@@ -1961,6 +1979,14 @@ export class TestPawSerializer extends UnitTest {
         const contextMock = new PawContextMock()
 
         let dummyError = new Error('dummy error')
+
+        importer.spyOn('_parserErrorHandler', (e) => {
+            throw e
+        })
+
+        importer.spyOn('_parserFailureHandler', (e) => {
+            throw e
+        })
 
         importer.spyOn('createRequestContexts', () => {
             return new Promise(() => {
@@ -2474,6 +2500,196 @@ export class TestPawSerializer extends UnitTest {
         let result = importer._unescapeURIFragment(input)
 
         this.assertEqual(expected, result)
+    }
+
+    @targets('_parserErrorHandler')
+    testParserErrorHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        let called = false
+        let threw = false
+        console.error = () => {
+            called = true
+        }
+
+        try {
+            importer._parserErrorHandler(new Error('Hey there'))
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertTrue(called)
+        this.assertTrue(threw)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_parserFailureHandler')
+    testParserFailureHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        let called = false
+        let threw = false
+        console.error = () => {
+            called = true
+        }
+
+        try {
+            importer._parserFailureHandler(new Error('Hey there'))
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertTrue(called)
+        this.assertTrue(threw)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_serializerFailureHandler')
+    testSerializerFailureHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        let called = false
+        let threw = false
+        console.error = () => {
+            called = true
+        }
+
+        try {
+            importer._serializerFailureHandler(new Error('Hey there'))
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertTrue(called)
+        this.assertTrue(threw)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_resolverErrorHandler')
+    testResolverErrorHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        let called = false
+        let threw = false
+        console.error = () => {
+            called = true
+        }
+
+        try {
+            importer._resolverErrorHandler(new Error('Hey there'))
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertTrue(called)
+        this.assertTrue(threw)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_resolverFailureHandler')
+    testResolverFailureHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        let called = false
+        let threw = false
+        console.error = () => {
+            called = true
+        }
+
+        try {
+            importer._resolverFailureHandler(new Error('Hey there'))
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertTrue(called)
+        this.assertTrue(threw)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_unsupportedAuthHandler')
+    testUnsupportdAuthHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        const expected = 'Auth type testAuth is not supported in Paw'
+
+        let result = null
+        let threw = false
+        console.error = (message) => {
+            result = message
+        }
+
+        try {
+            importer._unsupportedAuthHandler({
+                constructor: {
+                    name: 'testAuth'
+                }
+            })
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertFalse(threw)
+        this.assertEqual(result, expected)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
+    }
+
+    @targets('_invalidJSONHandler')
+    testInvalidJSONHandler() {
+        const importer = new ClassMock(new BaseImporter(), '')
+
+        /* eslint-disable no-console */
+        const oldConsoleError = console.error
+
+        const expected = 'body was set to JSON, but we couldn\'t parse it'
+
+        let result = null
+        let threw = false
+        console.error = (message) => {
+            result = message
+        }
+
+        try {
+            importer._invalidJSONHandler()
+        }
+        catch (e) {
+            threw = true
+        }
+
+        this.assertFalse(threw)
+        this.assertEqual(result, expected)
+        console.error = oldConsoleError
+        /* eslint-enable no-console */
     }
 
     @targets('serialize')


### PR DESCRIPTION
## READY FOR REVIEW

### Paw Parsers
- Paw Parser now supports default values for reference parameters

### DVs
- Updated DVManager to call convert after instantiation rather than during instantiation of DV
- Refactored EnvironmentVariable DV to be easily testable and more readable
- Added tests for EnvironmentVariable

### Paw Serializer
- Refactored Paw Serializer handling of errors in promise, so that the tests would not use the default `console.error` behavior
- Added tests for the Error Handling in Paw Serializer