### PR TITLE
Improve OAuth2 scopes management

### DIFF
--- a/src/models/Auth.js
+++ b/src/models/Auth.js
@@ -82,6 +82,12 @@ export class OAuth1Auth extends Immutable.Record({
     authorizationUri: null
 }) { }
 
+export class OAuth2Scope extends Immutable.Record({
+    name: null,
+    description: null,
+    value: null
+}) { }
+
 export class OAuth2Auth extends Immutable.Record({
     _model: new Model({
         name: 'oauth-2.auth.models',

--- a/src/parsers/paw/Parser.js
+++ b/src/parsers/paw/Parser.js
@@ -12,7 +12,7 @@ import URL from '../../models/URL'
 import Request from '../../models/Request'
 import Constraint from '../../models/Constraint'
 import Group from '../../models/Group'
-import Auth from '../../models/Auth'
+import Auth, { OAuth2Scope } from '../../models/Auth'
 import Reference from '../../models/references/Reference'
 import ReferenceContainer from '../../models/references/Container'
 import JSONSchemaReference from '../../models/references/JSONSchema'
@@ -1026,10 +1026,17 @@ export default class PawParser {
                 2: 'application',
                 3: 'password'
             }
-            let scopes = (oauth2.scope || '').split(' ')
+            let scopes = (oauth2.scope || '').split(/[\s,;]/)
 
             if (scopes.length === 1 && scopes[0] === '') {
                 scopes = null
+            }
+            else {
+                scopes = scopes.map(scope => {
+                    return new OAuth2Scope({
+                        value: scope
+                    })
+                })
             }
 
             let auth = new Auth.OAuth2({

--- a/src/parsers/paw/__tests__/Parser-test.js
+++ b/src/parsers/paw/__tests__/Parser-test.js
@@ -16,7 +16,7 @@ import Context, {
 
 import Group from '../../../models/Group'
 import Constraint from '../../../models/Constraint'
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 import Request from '../../../models/Request'
 import URL from '../../../models/URL'
 
@@ -1847,7 +1847,14 @@ export class TestPawParser extends UnitTest {
                 flow: 'implicit',
                 authorizationUrl: 'w;oeifhwe',
                 tokenUrl: 'h2oiufh23',
-                scopes: [ 'read:any', 'write:self' ]
+                scopes: new Immutable.List([
+                    new OAuth2Scope({
+                        value: 'read:any'
+                    }),
+                    new OAuth2Scope({
+                        value: 'write:self'
+                    })
+                ])
             })
         ])
 

--- a/src/parsers/postman/v2/Parser.js
+++ b/src/parsers/postman/v2/Parser.js
@@ -18,7 +18,7 @@ import URL from '../../../models/URL'
 import Group from '../../../models/Group'
 import Request from '../../../models/Request'
 
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 
 export default class PostmanParser {
     static format = 'postman'
@@ -615,6 +615,17 @@ export default class PostmanParser {
         })
     }
 
+    _extractOAuth2Scopes(_scope) {
+        let scopes = (_scope || '').split(/[\s,;]/)
+        scopes = scopes.map(scope => {
+            return new OAuth2Scope({
+                value: this._referenceEnvironmentVariable(scope)
+            })
+        })
+
+        return new Immutable.List(scopes)
+    }
+
     _extractOAuth2(auth) {
         return new Auth.OAuth1({
             authorizationUrl: this._referenceEnvironmentVariable(
@@ -623,9 +634,7 @@ export default class PostmanParser {
             accessTokenUrl: this._referenceEnvironmentVariable(
                 auth.tokenUrl
             ),
-            scopes: [ this._referenceEnvironmentVariable(
-                auth.scope
-            ) ]
+            scopes: this._extractOAuth2Scopes(auth.scope)
         })
     }
 

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -22,7 +22,7 @@ import ExoticReference from '../../../models/references/Exotic'
 import JSONSchemaReference from '../../../models/references/JSONSchema'
 
 import Constraint from '../../../models/Constraint'
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 
 import ShimmingFileReader from '../FileReader'
 
@@ -757,7 +757,18 @@ export default class RAMLParser {
         return auths
     }
 
+    _extractOAuth2Scopes(scopes) {
+        const _scopes = scopes.map(scope => {
+            return new OAuth2Scope({
+                value: scope
+            })
+        })
+
+        return new Immutable.List(_scopes)
+    }
+
     _extractOAuth2Auth(raml, authName = null, security, params) {
+        console.error('---------', security, params)
         let flowMap = {
             code: 'accessCode',
             token: 'implicit',
@@ -780,11 +791,10 @@ export default class RAMLParser {
                 _params.accessTokenUri ||
                 security.settings.accessTokenUri ||
                 null,
-            scopes:
-                new Immutable.List(
-                    _params.scopes ||
-                    security.settings.scopes || []
-                )
+            scopes: this._extractOAuth2Scopes(
+                _params.scopes ||
+                security.settings.scopes || []
+            )
         })
 
         return auth

--- a/src/parsers/swagger/v2.0/Parser.js
+++ b/src/parsers/swagger/v2.0/Parser.js
@@ -18,7 +18,7 @@ import {
 
 import Group from '../../../models/Group'
 import Request from '../../../models/Request'
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 import URL from '../../../models/URL'
 import Item from '../../../models/Item'
 
@@ -331,6 +331,16 @@ export default class SwaggerParser {
             in: definition.get('in'),
             name: definition.get('name')
         })
+    }
+
+    _setOAuth2Scopes(scopes) {
+        const _scopes = (scopes || []).map(scope => {
+            return new OAuth2Scope({
+                value: scope
+            })
+        })
+
+        return _scopes
     }
 
     _setOAuth2Auth(authName = null, definition) {

--- a/src/parsers/swagger/v2.0/__tests__/Parser-test.js
+++ b/src/parsers/swagger/v2.0/__tests__/Parser-test.js
@@ -20,7 +20,7 @@ import {
 
 import Group from '../../../../models/Group'
 import Constraint from '../../../../models/Constraint'
-import Auth from '../../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../../models/Auth'
 import Request from '../../../../models/Request'
 import URL from '../../../../models/URL'
 import Item from '../../../../models/Item'
@@ -1458,6 +1458,26 @@ export class TestSwaggerParser extends UnitTest {
         const result = parser._setApiKeyAuth('api_key', input)
 
         this.assertEqual(expected, result)
+    }
+
+    @targets('_setOAuth2Scopes')
+    testSetOAuth2Scopes() {
+        const parser = this.__init()
+
+        const scopes = [ 'read:any', 'write:own' ]
+
+        const expected = new Immutable.List([
+            new OAuth2Scope({
+                value: 'read:any'
+            }),
+            new OAuth2Scope({
+                value: 'write:own'
+            })
+        ])
+
+        const result = parser._setOAuth2Scopes(scopes)
+
+        this.assertEqual(result, expected)
     }
 
     @targets('_setOAuth2Auth')

--- a/src/serializers/paw/Serializer.js
+++ b/src/serializers/paw/Serializer.js
@@ -831,7 +831,9 @@ export default class PawSerializer {
                 accessTokenUrl: this._toDynamicString(
                     auth.get('tokenUrl') || '', true, 'auth'
                 ),
-                scope: (auth.get('scopes') || []).join(' ')
+                scope: (auth.get('scopes') || [])
+                    .map(scope => scope.get('value'))
+                    .join(' ')
             }
         )
     }

--- a/src/serializers/paw/__tests__/Serializer-test.js
+++ b/src/serializers/paw/__tests__/Serializer-test.js
@@ -13,7 +13,7 @@ import ExoticReference from '../../../models/references/Exotic'
 import Request from '../../../models/Request'
 import Constraint from '../../../models/Constraint'
 import URL from '../../../models/URL'
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 
 import PawEnvironment from '../../../models/environments/PawEnvironment'
 import ContextResolver from '../../../resolvers/ContextResolver'
@@ -826,7 +826,14 @@ export class TestPawSerializer extends UnitTest {
             flow: 'implicit',
             authorizationUrl: 'fakeurl.com/oauth2',
             tokenUrl: 'fakeurl.com/oauth2/access-token',
-            scopes: [ 'user:write', 'user:read' ]
+            scopes: new Immutable.List([
+                new OAuth2Scope({
+                    value: 'user:write'
+                }),
+                new OAuth2Scope({
+                    value: 'user:read'
+                })
+            ])
         })
 
         let dv = importer._setOAuth2Auth(auth)

--- a/src/serializers/raml/Serializer.js
+++ b/src/serializers/raml/Serializer.js
@@ -876,7 +876,9 @@ export default class RAMLSerializer extends BaseSerializer {
                 if (scopes && scopes.size > 0) {
                     content = {}
                     content.oauth_2_0 = {
-                        scopes: scopes.toJS()
+                        scopes: (scopes || []).map(scope => {
+                            return scope.get('value')
+                        })
                     }
                 }
                 else {

--- a/src/serializers/raml/__tests__/Serializer-test.js
+++ b/src/serializers/raml/__tests__/Serializer-test.js
@@ -13,7 +13,7 @@ import {
     Info, Contact, License
 } from '../../../models/Utils'
 
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 import Constraint from '../../../models/Constraint'
 import URL from '../../../models/URL'
 import Request from '../../../models/Request'
@@ -735,7 +735,14 @@ export class TestRAMLSerializer extends UnitTest {
                         flow: 'implicit',
                         authorizationUrl: 'api.com/oauth2/authorize',
                         tokenUrl: 'api.com/oauth2/token',
-                        scopes: Immutable.List([ 'read:any', 'write:own' ])
+                        scopes: Immutable.List([
+                            new OAuth2Scope({
+                                value: 'read:any'
+                            }),
+                            new OAuth2Scope({
+                                value: 'write:own'
+                            })
+                        ])
                     })
                 ])
             }),
@@ -804,7 +811,14 @@ export class TestRAMLSerializer extends UnitTest {
             flow: 'implicit',
             authorizationUrl: 'api.com/oauth2/authorize',
             tokenUrl: 'api.com/oauth2/token',
-            scopes: Immutable.List([ 'read:any', 'write:own' ])
+            scopes: Immutable.List([
+                new OAuth2Scope({
+                    value: 'read:any'
+                }),
+                new OAuth2Scope({
+                    value: 'write:own'
+                })
+            ])
         })
 
         let expected = {
@@ -1785,7 +1799,12 @@ export class TestRAMLSerializer extends UnitTest {
         const input = new Immutable.List([
             new Auth.OAuth2({
                 scopes: new Immutable.List([
-                    'read:any', 'write:self'
+                    new OAuth2Scope({
+                        value: 'read:any'
+                    }),
+                    new OAuth2Scope({
+                        value: 'write:self'
+                    })
                 ])
             })
         ])

--- a/src/serializers/swagger/Serializer.js
+++ b/src/serializers/swagger/Serializer.js
@@ -798,7 +798,7 @@ export default class SwaggerSerializer extends BaseSerializer {
     }
 
     _formatOAuth2Auth(context, auth) {
-        let scopes = auth.get('scopes')
+        let scopes = (auth.get('scopes') || []).map(scope => scope.get('value'))
         const name = auth.get('authName') || 'oauth_2_auth'
 
         let _definition = {
@@ -827,7 +827,6 @@ export default class SwaggerSerializer extends BaseSerializer {
         let scopeDescriptions = {}
         let security
         if (scopes) {
-            scopes = Array.isArray(scopes) ? scopes : scopes.toJS()
             security = {}
             security[name] = scopes
 

--- a/src/serializers/swagger/__tests__/Serializer-test.js
+++ b/src/serializers/swagger/__tests__/Serializer-test.js
@@ -24,7 +24,7 @@ import {
 
 
 import Constraint from '../../../models/Constraint'
-import Auth from '../../../models/Auth'
+import Auth, { OAuth2Scope } from '../../../models/Auth'
 import URL from '../../../models/URL'
 import Request from '../../../models/Request'
 
@@ -1277,7 +1277,14 @@ export class TestSwaggerSerializer extends UnitTest {
             authorizationUrl: 'test.com/auth',
             tokenUrl: 'test.com/token',
             flow: 'implicit',
-            scopes: new Immutable.List([ 'write:self', 'read:any' ])
+            scopes: new Immutable.List([
+                new OAuth2Scope({
+                    value: 'write:self'
+                }),
+                new OAuth2Scope({
+                    value: 'read:any'
+                })
+            ])
         })
 
         const expected = [


### PR DESCRIPTION
### Model
- adds an OAuth2Scope object to the model

### Parsers
- updated all relevant parsers with OAuth2Scope

### Serializers
- updated Paw, RAML and Swagger parsers with OAuth2Scope