### PR TITLE
106 improve raml file resolution

### DIFF
--- a/src/mocks/PawMocks.js
+++ b/src/mocks/PawMocks.js
@@ -176,6 +176,25 @@ export class InputField extends Mock {
     }
 }
 
+export class NetworkHTTPRequest extends Mock {
+    constructor(prefix = '') {
+        let obj = {
+            requestUrl: null,
+            requestMethod: null,
+            requestTimeout: null,
+            requestBody: null,
+            responseStatusCode: null,
+            responseHeaders: null,
+            responseBody: null,
+            setRequestHeader: () => {},
+            getRequestHeader: () => {},
+            getResponseHeader: () => {},
+            send: () => {}
+        }
+        super(obj, prefix)
+    }
+}
+
 export const registerImporter = (_class) => {
     return _class
 }

--- a/src/mocks/PawShims.js
+++ b/src/mocks/PawShims.js
@@ -3,7 +3,8 @@ if (
     typeof DynamicValue === 'undefined' ||
     typeof DynamicString === 'undefined' ||
     typeof registerCodeGenerator === 'undefined' ||
-    typeof InputField === 'undefined'
+    typeof InputField === 'undefined' ||
+    typeof NetworkHTTPRequest === 'undefined'
 ) {
     let mocks = require('./PawMocks.js')
     module.exports = {
@@ -11,7 +12,8 @@ if (
         DynamicValue: mocks.DynamicValue,
         DynamicString: mocks.DynamicString,
         registerCodeGenerator: mocks.registerCodeGenerator,
-        InputField: mocks.InputField
+        InputField: mocks.InputField,
+        NetworkHTTPRequest: mocks.NetworkHTTPRequest
     }
 }
 else {
@@ -21,7 +23,8 @@ else {
         DynamicValue: DynamicValue,
         DynamicString: DynamicString,
         registerCodeGenerator: registerCodeGenerator,
-        InputField: InputField
+        InputField: InputField,
+        NetworkHTTPRequest: NetworkHTTPRequest
     }
     /* eslint-enable no-undef */
 }

--- a/src/models/environments/PawEnvironment.js
+++ b/src/models/environments/PawEnvironment.js
@@ -1,5 +1,6 @@
 import Environment from './Environment'
 import Model from '../ModelInfo'
+import { NetworkHTTPRequest } from '../../mocks/PawShims'
 
 export class FileResolver {
     static _model = new Model({
@@ -28,7 +29,27 @@ export class URLResolver {
 
     resolve(uri) {
         return new Promise((resolve, reject) => {
-            return reject(new Error('resolver not implemented for ' + uri))
+            if (uri === '') {
+                return resolve(this.item.content)
+            }
+            else {
+                let url = new URL(uri, this.item.get('url')).href()
+                let request = new NetworkHTTPRequest()
+                request.requestUrl = url
+                request.requestMethod = 'GET'
+                request.requestTimeout = 20 * 1000
+                const status = request.send()
+
+                if (status && request.responseStatusCode < 300) {
+                    resolve(request.responseBody)
+                }
+                else {
+                    const msg = 'Failed to fetch ' +
+                        uri + '. Got code: ' +
+                        request.responseStatusCode
+                    reject(new Error(msg))
+                }
+            }
         })
     }
 }

--- a/src/models/environments/__tests__/PawEnvironment-test.js
+++ b/src/models/environments/__tests__/PawEnvironment-test.js
@@ -188,10 +188,10 @@ export class TestURLResolver extends UnitTest {
 
         let result = resolver.resolve('')
         result.then(() => {
-            this.assertFalse(true)
+            this.assertTrue(true)
             done()
         }, () => {
-            this.assertTrue(true)
+            this.assertFalse(true)
             done()
         }).catch(error => {
             done(new Error(error))

--- a/src/parsers/raml/FileReader.js
+++ b/src/parsers/raml/FileReader.js
@@ -1,12 +1,27 @@
 import path from 'path-browserify'
 
+import Item from '../../models/Item'
+
 export default class ShimmingFileReader {
-    constructor(items) {
+    constructor(items, UrlResolverClass) {
         this.baseItem = ''
         this.items = items || []
+        this.urlResolver = null
+
+        if (UrlResolverClass) {
+            this.urlResolver = new UrlResolverClass(new Item())
+        }
     }
 
     readFileAsync(filePath) {
+        if (/^https?/i.test(filePath) && this.urlResolver) {
+            return this.urlResolver.resolve(filePath)
+                .then(content => content, () => {
+                    return '::fileRef::' +
+                        path.relative(path.dirname(this.baseItem), filePath)
+                })
+        }
+
         for (let item of this.items) {
             if (filePath.indexOf(
                 path.join(item.file.path, item.file.name)

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -69,6 +69,10 @@ export default class RAMLParser {
         return RAMLParser.getAPIName(...arguments)
     }
 
+    setFileReader(items, urlResolverClass) {
+        this.reader = new ShimmingFileReader(items, urlResolverClass)
+    }
+
     parse(_item) {
         this.item = new Item(_item)
         this.reader.setBaseItem(this.item)

--- a/src/parsers/raml/v0.8/Parser.js
+++ b/src/parsers/raml/v0.8/Parser.js
@@ -836,7 +836,7 @@ export default class RAMLParser {
         let responses = new Immutable.List()
 
         for (let code of Object.keys(req.responses || {})) {
-            let response = req.responses[code]
+            let response = req.responses[code] || {}
             let description = response.description || null
 
             let [ _container, _bodies ] = this._extractBodies(

--- a/src/parsers/raml/v0.8/__tests__/Parser-test.js
+++ b/src/parsers/raml/v0.8/__tests__/Parser-test.js
@@ -2427,6 +2427,24 @@ export class TestRAMLParser extends UnitTest {
         this.assertEqual(expected, result)
     }
 
+    @targets('setFileReader')
+    testSetFileReader() {
+        const parser = new ClassMock(new RAMLParser())
+
+        parser.reader = new ShimmingFileReader([ 1, 2, 3 ])
+        const items = [ 1, 2, 3, 4, 5 ]
+
+        class UrlResolver {}
+        const urlResolverClass = UrlResolver
+        parser.setFileReader(items, urlResolverClass)
+
+        const fileReader = parser.reader
+
+        this.assertTrue(fileReader instanceof ShimmingFileReader)
+        this.assertEqual(fileReader.items, items)
+        this.assertJSONEqual(fileReader.urlResolver, new UrlResolver())
+    }
+
     __init(file) {
         let raml = this.__loadRAMLObject(file)
         let parser = new RAMLParser()

--- a/src/runners/paw-importer/raml/Importer.js
+++ b/src/runners/paw-importer/raml/Importer.js
@@ -2,6 +2,7 @@ import { registerImporter } from '../../../mocks/PawShims'
 
 import BaseImporter from '../../../serializers/paw/Serializer'
 import RAMLParser from '../../../parsers/raml/Parser'
+import { URLResolver } from '../../../models/environments/PawEnvironment'
 
 @registerImporter // eslint-disable-line
 export default class RAMLImporter extends BaseImporter {
@@ -39,7 +40,7 @@ export default class RAMLImporter extends BaseImporter {
     */
     createRequestContexts(context, items) {
         const parser = this.parser
-
+        parser.setFileReader(items, URLResolver)
         let reqPromises = []
         for (let item of items) {
             if (this._startsWithRAMLVersion(item)) {


### PR DESCRIPTION
### Mocks
- added NetworkHttpRequest mock and shim

### Model
- PawEnvironment URLResolver can now resolve urls

### Parsers
- RAMLParser now exposes a `setFileReader` method that can be used to update the fileReader with the correct context (items and urlResolver)

### Runners
- RAMLImporter now sets it RAMLParser's fileReader using the `setFileReader` method