### PR TITLE
126 postman 2 parser

### DIFF
--- a/configs/paw/importers/postman2/api-flow-config.js
+++ b/configs/paw/importers/postman2/api-flow-config.js
@@ -1,0 +1,28 @@
+import Environment from '../../../../src/environments/paw/Environment'
+
+import PostmanCollectionV2Loader from '../../../../src/loaders/postman/v2.0/Loader'
+
+import PostmanCollectionV2Parser from '../../../../src/parsers/postman/v2.0/Parser'
+
+import PawSerializer from '../../../../src/serializers/paw/Serializer'
+
+export const loaders = [
+  PostmanCollectionV2Loader
+]
+
+export const parsers = [
+  PostmanCollectionV2Parser
+]
+
+export const serializers = [
+  PawSerializer
+]
+
+export const source = {
+  identifier: 'com.luckymarmot.PawExtensions.PostmanCollectionV2Importer',
+  title: 'PostmanCollectionV2Importer',
+  format: PostmanCollectionV2Parser.__meta__.format,
+  version: PostmanCollectionV2Parser.__meta__.version
+}
+
+export const environment = Environment

--- a/configs/paw/importers/postman2/webpack.config.babel.js
+++ b/configs/paw/importers/postman2/webpack.config.babel.js
@@ -1,0 +1,40 @@
+const { source } = require('./api-flow-config.js')
+
+const path = require('path')
+
+const config = {
+  target: 'web',
+  entry: path.resolve(__dirname, '../Importer.js'),
+  output: {
+    path: path.resolve(__dirname, '../../../../dist/paw/', source.identifier),
+    filename: source.title + '.js',
+    libraryTarget: 'umd'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: 'babel-loader',
+        include: [ path.resolve(__dirname, '../../../../src'), path.resolve(__dirname, '../') ]
+      },
+      {
+        test: /\.json$/,
+        use: 'json-loader',
+        include: [ path.resolve(__dirname, '../../../../') ]
+      }
+    ],
+    noParse: /node_modules\/json-schema\/lib\/validate\.js/
+  },
+  resolve: {
+    alias: {
+      'api-flow-config$': path.resolve(__dirname, './api-flow-config.js')
+    }
+  },
+  node: {
+    fs: false,
+    request: false,
+    net: false,
+    tls: false
+  }
+}
+module.exports = config

--- a/src/environments/paw/Environment.js
+++ b/src/environments/paw/Environment.js
@@ -14,7 +14,7 @@ methods.setCache = ($cache) => {
 }
 
 methods.fsResolve = (uri) => {
-  const cleanUri = uri.split('#')[0]
+  const cleanUri = decodeURIComponent(uri.split('#')[0])
 
   if (cache[cleanUri]) {
     return Promise.resolve(cache[cleanUri])

--- a/src/loaders/postman/v2.0/Loader.js
+++ b/src/loaders/postman/v2.0/Loader.js
@@ -375,6 +375,10 @@ methods.extractGlobalsFromFileBody = (body) => {
 }
 
 methods.extractGlobalsFromBody = (body) => {
+  if (!body) {
+    return []
+  }
+
   if (body.raw) {
     return methods.extractGlobalsFromRawBody(body.raw)
   }

--- a/src/loaders/postman/v2.0/__tests__/Loader.spec.js
+++ b/src/loaders/postman/v2.0/__tests__/Loader.spec.js
@@ -783,6 +783,7 @@ describe('loaders/postman/v2.0/Loader.js', () => {
       spyOn(__internals__, 'extractGlobalsFromFileBody').andCall(v => [ v * 4 ])
 
       const inputs = [
+        null,
         {},
         { raw: 123 },
         { mode: 'urlencoded', urlencoded: 234 },
@@ -790,6 +791,7 @@ describe('loaders/postman/v2.0/Loader.js', () => {
         { mode: 'file', file: 456 }
       ]
       const expected = [
+        [],
         [],
         [ 123 * 2 ],
         [ 234 * 3 ],

--- a/src/parsers/postman/v2.0/Parser.js
+++ b/src/parsers/postman/v2.0/Parser.js
@@ -456,7 +456,7 @@ methods.findLongestCommonPath = (lcPathname, pathname) => {
 }
 
 methods.addHostEntryToHostMap = (hostMap, { key, value }) => {
-  const hostname = key.get('hostname').generate(List([ '{{', '}}' ]))
+  const hostname = key.get('hostname') ? key.get('hostname').generate(List([ '{{', '}}' ])) : ''
   const port = key.get('port') ? ':' + key.get('port').generate(List([ '{{', '}}' ])) : ''
   const host = hostname + port
   const pathname = key.get('pathname').generate(List([ '{{', '}}' ]))

--- a/src/parsers/postman/v2.0/__tests__/Parser.spec.js
+++ b/src/parsers/postman/v2.0/__tests__/Parser.spec.js
@@ -953,6 +953,13 @@ describe('parsers/postman/v2.0/Parser.js', () => {
             variableDelimiters: List([ '{{', '}}', ':' ])
           }),
           value: 321
+        },
+        {
+          key: new URL({
+            url: 'https:///users/321',
+            variableDelimiters: List([ '{{', '}}', ':' ])
+          }),
+          value: 321
         }
       ]
       const expected = {
@@ -992,6 +999,18 @@ describe('parsers/postman/v2.0/Parser.js', () => {
             {
               key: new URL({
                 url: 'https://beta.paw.cloud/users/321',
+                variableDelimiters: List([ '{{', '}}', ':' ])
+              }),
+              value: 321
+            }
+          ],
+          lcPathname: [ '', 'users', '321' ]
+        },
+        '': {
+          entries: [
+            {
+              key: new URL({
+                url: 'https:///users/321',
                 variableDelimiters: List([ '{{', '}}', ':' ])
               }),
               value: 321


### PR DESCRIPTION
- [x] adds configuration files for the PostmanCollectionV2Importer
- [x] fixes a bug where the Paw environment would fail to resolve files with spaces in it (needed a `decodeURIComponent`)
- [x] fixes a bug where the Postman loader would crash if a request had no body.
- [x] fixes a bug where the Postman parser crashes if a request has no host (e.g. `https:///users/whatever`)