### PR TITLE
fixed a bug where swagger contentTypes could include charsets data

### DIFF
--- a/src/serializers/swagger/v2.0/Serializer.js
+++ b/src/serializers/swagger/v2.0/Serializer.js
@@ -1479,11 +1479,11 @@ methods.isProducesHeader = (param) => {
 methods.extractContentTypesFromParam = (param) => {
   const schema = param.getJSONSchema(false)
   if (schema.enum) {
-    return schema.enum
+    return schema.enum.map(contentType => contentType.split(';')[0])
   }
 
   if (schema.default) {
-    return [ schema.default ]
+    return [ schema.default ].map(contentType => contentType.split(';')[0])
   }
 
   return []


### PR DESCRIPTION
- `application/json; charset=utf-8` is not a valid `consumes`/`produces` value. This is now shortened to `application/json`