### PR TITLE
Rejigged README a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,20 @@ We intend to support:
 - and many more.
 
 ## Installation
-### from a cloned repository
 
-just run
+You can install this library in two different ways. 
+
+### Install via NPM/Yarn 
+
+```shell
+$ yarn add api-flow
+# or 
+$ npm install api-flow
+```
+
+### Install from source
+
+Just run:
 
 ```sh
 git clone https://github.com/luckymarmot/API-Flow.git
@@ -31,19 +42,12 @@ cd API-Flow
 make install
 ```
 
-This will install the node module dependencies
-
-## Building the different libraries
-### node, web, and webworker
-
-run the following command to build API-Flow for the different environments that you need
+This will install the node module dependencies, but you will need to build API-Flow for the different environments that you need:
 
 ```sh
 # use TARGET="node" if you only want the node library
 make runners TARGET="node web webworker"
 ```
-
-### Paw
 
 You can use the following command to add the different extensions to Paw
 
@@ -52,12 +56,15 @@ You can use the following command to add the different extensions to Paw
 make transfer TARGET="swagger raml1 postman2"
 ```
 
-## Using the npm module
-### as a standard library
+## Usage
+
+### Standard Library
 
 ```js
-const ApiFlow = require('api-flow'); // if from npm
+const ApiFlow = require('api-flow'); // if from yarn/npm
 const ApiFlow = require('./dist/node/api-flow.js'); // if from `make runners TARGET="node"`
+
+const path = require('path');
 
 const options = {
     source: {


### PR DESCRIPTION
I'm excited about API Flow, but the README had me installing from source with me only noticing I could just yarn install later. I think the default for most folks is installing the package, not building from source. 

I've also added `const path = require('path');` as it was erring before that. 

Still, this is giving me trouble:  

```
$ node scripts/openapi_to_postman.js
/Users/psturgeon/src/apis/scripts/openapi_to_postman.js:15
const promise = ApiFlow.transform({
                        ^

TypeError: ApiFlow.transform is not a function
    at Object.<anonymous> (/Users/psturgeon/src/apis/scripts/openapi_to_postman.js:15:25)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
```

I'd love to get the README in line with how things work, just gimme some hints! :)