### PR TITLE
Fix convertAuthFromReference in Paw serializer

### DIFF
--- a/src/serializers/paw/Serializer.js
+++ b/src/serializers/paw/Serializer.js
@@ -1029,12 +1029,12 @@ methods.getContainerFromRequest = (request) => {
  * converts an auth into a DynamicString from a reference.
  * @param {Store} store: the store to use to resolve the reference
  * @param {Reference} reference: the reference to an EnvironmentVariable representing an Auth.
- * @returns {DynamicString} the corresponding DynamicString
+ * @returns {{ variable: DynamicString, auth: Auth }} the corresponding DynamicString
  */
 methods.convertAuthFromReference = (store, reference) => {
-  const variable = store.getIn([ 'auth', reference.get('uuid') ])
+  const { variable, auth } = store.getIn([ 'auth', reference.get('uuid') ])
   const ds = variable.createDynamicString()
-  return ds
+  return { variable: ds, auth: auth }
 }
 
 /**

--- a/src/serializers/paw/__tests__/Serializer.spec.js
+++ b/src/serializers/paw/__tests__/Serializer.spec.js
@@ -2010,12 +2010,12 @@ describe('serializers/paw/Serializer.js', () => {
       spyOn(variable, 'createDynamicString').andReturn(123)
 
       const store = new Store({
-        auth: OrderedMap({ a: variable })
+        auth: OrderedMap({ a: { variable: variable, auth: 'my-auth' } })
       })
 
       const ref = new Reference({ uuid: 'a' })
 
-      const expected = 123
+      const expected = { auth: 'my-auth', variable: 123 }
       const actual = __internals__.convertAuthFromReference(store, ref)
 
       expect(actual).toEqual(expected)


### PR DESCRIPTION
Fixes [a bug reported](https://github.com/luckymarmot/API-Flow/pull/141#issuecomment-335196765) by @caffeineflo following PR #141

> 
`variable.createDynamicString is not a function. (In 'variable.createDynamicString()', 'variable.createDynamicString' is undefined)`
