### PR TITLE
Please dont make contributors hunt for instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+PRs are always welcome, and we'll be happy to merge them if the test suite passes.
+
+To run the entire test suite would take a long time, so we've broken it down into various groups:
+
+``` shell
+TEST_TARGET=lint make test
+TEST_TARGET=unit make test
+TEST_TARGET=e2e make test
+TEST_TARGET=cov make test
+```
+
+All of these will be run by Travis, but you could save the ice caps from melting a little by running at least `unit` and `e2e` before you push.
+
+Our sole requirement is that organizations that want to extend API-Flow to support their format write both a parser and a serializer, and not simply a serializer.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Our sole requirement is that organizations that want to extend API-Flow to suppo
 
 ## Documentation
 
-You can find more information about the internal structure of API-Flow in [src](https://github.com/luckymarmot/API-Flow/tree/develop/src). We've also created a set of templates to help speed up the extension process: [loader](https://github.com/luckymarmot/API-Flow/tree/develop/src/loaders/template/v1.0), [parser](https://github.com/luckymarmot/API-Flow/tree/develop/src/parsers/template/v1.0/), and [environment](https://github.com/luckymarmot/API-Flow/tree/develop/src/environments/template)
+You can find more information about the internal structure of API-Flow in [src](src). We've also created a set of templates to help speed up the extension process: [loader](src/loaders/template/v1.0), [parser](src/parsers/template/v1.0/), and [environment](src/environments/template)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ API-Flow is one of the main components of [Console.REST](https://github.com/luck
 
 ## Contributing
 
-PRs are welcomed!
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for more tips on testing and contributing.
+
 Our sole requirement is that organizations that want to extend API-Flow to support their format write both a parser and a serializer, and not simply a serializer.
 
 ## Documentation
+
 You can find more information about the internal structure of API-Flow in [src](https://github.com/luckymarmot/API-Flow/tree/develop/src). We've also created a set of templates to help speed up the extension process: [loader](https://github.com/luckymarmot/API-Flow/tree/develop/src/loaders/template/v1.0), [parser](https://github.com/luckymarmot/API-Flow/tree/develop/src/parsers/template/v1.0/), and [environment](https://github.com/luckymarmot/API-Flow/tree/develop/src/environments/template)
 
 ## License


### PR DESCRIPTION
Nice easy tips for contributors getting started, who might not know where to look otherwise.