### PR TITLE
Postman cannot have a null header value

### DIFF
--- a/src/serializers/postman/v2.0/Serializer.js
+++ b/src/serializers/postman/v2.0/Serializer.js
@@ -620,7 +620,7 @@ methods.createHeaderFromParameter = (param) => {
     return { key, value: schema.enum[0] }
   }
 
-  return { key, value: null }
+  return { key, value: '' }
 }
 
 /**

--- a/src/serializers/postman/v2.0/__tests__/Serializer.spec.js
+++ b/src/serializers/postman/v2.0/__tests__/Serializer.spec.js
@@ -844,7 +844,7 @@ describe('serializers/swagger/v2.0/Serializer.js', () => {
       ]
       const expected = [
         null,
-        { key: 123, value: null },
+        { key: 123, value: '' },
         { key: 234, value: 'abc' },
         { key: 345, value: 'def' }
       ]

--- a/testing/e2e/internal-postman2/test-case-0/output.json
+++ b/testing/e2e/internal-postman2/test-case-0/output.json
@@ -170,7 +170,7 @@
             "header": [
               {
                 "key": "api_key",
-                "value": null
+                "value": ""
               },
               {
                 "key": "Content-Type",


### PR DESCRIPTION
Trying to upload the generated Postman file to Postman Pro gives a JSON Schema failure. Running it locally, this change removed one error. It's possible their JSON Schema is just a bit harsh, but its failing and this fixes it.